### PR TITLE
Automatically generate a sensible extension version number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SETTINGS_FILE := settings/chrome-prod.json
+SETTINGS_FILE := settings/chrome-dev.json
 
 BROWSERIFY := node_modules/.bin/browserify
 EXORCIST := node_modules/.bin/exorcist
@@ -19,7 +19,9 @@ clean:
 # the appropriate things being rebuilt.
 .PHONY: force
 build/.settings.json: force
-	@cmp -s $(SETTINGS_FILE) $@ || cat $(SETTINGS_FILE) >$@
+	@tools/settings.js $(SETTINGS_FILE) | \
+	cmp -s - $@ || \
+	tools/settings.js $(SETTINGS_FILE) >$@
 
 EXTENSION_SRC := content help images lib
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypothesis-browser-extension",
-  "version": "0.0.0",
+  "version": "0.34.0",
   "private": true,
   "description": "Annotate with anyone, anywhere.",
   "license": "BSD-2-Clause",
@@ -14,7 +14,8 @@
     "core-js": "^1.2.5",
     "diff": "^2.2.2",
     "exorcist": "^0.4.0",
-    "hypothesis": "^0.32.0",
+    "git-describe": "^3.0.1",
+    "hypothesis": "^0.34.0",
     "is-equal-shallow": "^0.1.3",
     "js-polyfills": "^0.1.16",
     "jscs": "^3.0.2",

--- a/settings/chrome-dev.json
+++ b/settings/chrome-dev.json
@@ -1,0 +1,9 @@
+{
+  "buildType": "dev",
+
+  "apiUrl": "http://localhost:5000/api/",
+  "serviceUrl": "http://localhost:5000/",
+  "websocketUrl": "ws://localhost:5001/ws",
+
+  "browserIsChrome": true
+}

--- a/settings/chrome-prod.json
+++ b/settings/chrome-prod.json
@@ -1,8 +1,6 @@
 {
-  "version": "0.34.0",
-  "versionName": "Official Build",
-
   "buildType": "production",
+
   "apiUrl": "https://hypothes.is/api/",
   "bouncerUrl": "https://hyp.is/",
   "serviceUrl": "https://hypothes.is/",

--- a/settings/firefox-dev.json
+++ b/settings/firefox-dev.json
@@ -1,0 +1,9 @@
+{
+  "buildType": "dev",
+
+  "apiUrl": "http://localhost:5000/api/",
+  "serviceUrl": "http://localhost:5000/",
+  "websocketUrl": "ws://localhost:5001/ws",
+
+  "browserIsFirefox": true
+}

--- a/settings/firefox-prod.json
+++ b/settings/firefox-prod.json
@@ -1,8 +1,6 @@
 {
-  "version": "0.34.0",
-  "versionName": "Official Build",
-
   "buildType": "production",
+
   "apiUrl": "https://hypothes.is/api/",
   "bouncerUrl": "https://hyp.is/",
   "serviceUrl": "https://hypothes.is/",

--- a/tools/settings.js
+++ b/tools/settings.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+/**
+ * Outputs a JSON object representing the extension settings based on a settings
+ * file and the package environment.
+ */
+
+'use strict';
+
+const path = require('path');
+const gitDescribeSync = require('git-describe').gitDescribeSync;
+
+// Suppress (expected) EPIPE errors on STDOUT
+process.stdout.on('error', err => {
+  if (err.code === 'EPIPE') { process.exit(); }
+});
+
+/**
+ * getVersion fetches the current version from git, applying the following
+ * rules:
+ *
+ * - If buildType is 'production' and the git state is not clean, throw an error
+ * - Set the version number to X.Y.Z.W, where X.Y.Z is the last tagged release
+ *   and W is the number of commits since that release.
+ * - If the buildType is 'production', set the version name to "Official Build",
+ *   otherwise set it to a string of the form "gXXXXXXX[.dirty]" to reflect the
+ *   exact commit and state of the repository.
+ */
+function getVersion(buildType) {
+  const gitInfo = gitDescribeSync();
+
+  if (buildType === 'production' && gitInfo.dirty) {
+    throw new Error('cannot create production build with dirty git state!');
+  }
+
+  const version = `${gitInfo.semver}.${gitInfo.distance}`;
+  let versionName = 'Official Build';
+
+  if (buildType !== 'production') {
+    versionName = `${gitInfo.hash}${gitInfo.dirty ? '.dirty' : ''}`;
+  }
+
+  return {version, versionName};
+}
+
+if (process.argv.length !== 3) {
+  console.error("Usage: %s <settings.json>", path.basename(process.argv[1]));
+  process.exit(1);
+}
+
+const settings = require(path.join(process.cwd(), process.argv[2]));
+const settingsOut = Object.assign({}, settings, getVersion(settings.buildType));
+
+console.log(JSON.stringify(settingsOut));


### PR DESCRIPTION
This commit sets up the build to automatically generate a sensible version number and version name on the basis of:

- the latest git tag, which is assumed to reflect the version of the underlying client
- the number of commits since that tag
- whether or not the build is a 'production' build