### PR TITLE
Make dev bouncer work with dev Chrome extension

### DIFF
--- a/settings/chrome-dev.json
+++ b/settings/chrome-dev.json
@@ -2,6 +2,7 @@
   "buildType": "dev",
 
   "apiUrl": "http://localhost:5000/api/",
+  "bouncerUrl": "http://localhost:8000/",
   "serviceUrl": "http://localhost:5000/",
   "websocketUrl": "ws://localhost:5001/ws",
 


### PR DESCRIPTION
By default a dev install of bouncer runs at http://localhost:8000/.

Even if you've correctly configured bouncer with your dev Chrome
extension ID in an environment variable, your dev bouncer links won't
work (they'll redirect to Via instead of to your dev Chrome extension)
unless your dev Chrome extension is also configured with your dev
bouncer URL.

We used to be able to do this with the --bouncer arg to the
hypothesis-buildext command.

With this new Makefile for building the Chrome extension, it seems
better for a dev Chrome extensions to work with a dev bouncer (running
at the default dev bouncer URL) than to not work with any bouncer at
all.