### PR TITLE
Setup ESLint using shared config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+build/**
+**/vendor/**/*.js
+
+# Ignore PDF.js build
+src/chrome/content

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "hypothesis",
+  "globals": {
+    "chrome": false
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SETTINGS_FILE := settings/chrome-dev.json
 
 BROWSERIFY := node_modules/.bin/browserify
+ESLINT := node_modules/.bin/eslint
 EXORCIST := node_modules/.bin/exorcist
 MUSTACHE := node_modules/.bin/mustache
 
@@ -64,5 +65,9 @@ build/%: src/chrome/%
 
 dist/%.zip dist/%.xpi: extension
 	cd build && find . -not -path '*/\.*' -type f | zip -q -@ $(abspath $@)
+
+.PHONY: lint
+lint:
+	$(ESLINT) .
 
 -include build/.*.deps

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "check-dependencies": "^0.12.0",
     "core-js": "^1.2.5",
     "diff": "^2.2.2",
+    "eslint": "^3.2.0",
+    "eslint-config-hypothesis": "^1.0.0",
     "exorcist": "^0.4.0",
     "git-describe": "^3.0.1",
     "hypothesis": "^0.36.0",

--- a/src/chrome/help/index.js
+++ b/src/chrome/help/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /** Parse a query string into an object mapping param names to values. */
 function parseQuery(query) {
   if (query.charAt(0) === '?') {

--- a/src/chrome/lib/destroy.js
+++ b/src/chrome/lib/destroy.js
@@ -1,15 +1,14 @@
 // Script injected into the page to trigger removal of any existing instances
 // of the Hypothesis client.
-(function () {
-  'use strict';
 
-  var annotatorLink =
-    document.querySelector('link[type="application/annotator+html"]');
+'use strict';
 
-  if (annotatorLink) {
-    // Dispatch a 'destroy' event which is handled by the code in
-    // annotator/main.js to remove the client.
-    var destroyEvent = new Event('destroy');
-    annotatorLink.dispatchEvent(destroyEvent);
-  }
-}());
+var annotatorLink =
+  document.querySelector('link[type="application/annotator+html"]');
+
+if (annotatorLink) {
+  // Dispatch a 'destroy' event which is handled by the code in
+  // annotator/main.js to remove the client.
+  var destroyEvent = new Event('destroy');
+  annotatorLink.dispatchEvent(destroyEvent);
+}

--- a/src/common/browser-action.js
+++ b/src/common/browser-action.js
@@ -11,11 +11,11 @@ var states = TabState.states;
 var icons = {};
 icons[states.ACTIVE] = {
   19: 'images/browser-icon-active.png',
-  38: 'images/browser-icon-active@2x.png'
+  38: 'images/browser-icon-active@2x.png',
 };
 icons[states.INACTIVE] = {
   19: 'images/browser-icon-inactive.png',
-  38: 'images/browser-icon-inactive@2x.png'
+  38: 'images/browser-icon-inactive@2x.png',
 };
 
 var buildType = settings.buildType;
@@ -30,7 +30,7 @@ var badgeThemes = {
   'staging': {
     defaultText: 'STG',
     color: '#EDA061', // Porche orange-pink
-  }
+  },
 };
 
 // Fake localization function.
@@ -101,7 +101,7 @@ function BrowserAction(chromeBrowserAction) {
     chromeBrowserAction.setBadgeText({tabId: tabId, text: badgeText});
     chromeBrowserAction.setIcon({tabId: tabId, path: activeIcon});
     chromeBrowserAction.setTitle({tabId: tabId, title: title});
-  }
+  };
 }
 
 BrowserAction.icons = icons;

--- a/src/common/detect-content-type.js
+++ b/src/common/detect-content-type.js
@@ -25,9 +25,10 @@ function detectContentType(document_) {
     // see this document, open the inspector on a PDF viewer tab with
     // Ctrl+Shift+I rather than right-clicking on the viewport and selecting the
     // 'Inspect' option which will instead show the _inner_ document.
-    if (!!document_.querySelector('embed[type="application/pdf"][name="plugin"]')) {
+    if (document_.querySelector('embed[type="application/pdf"][name="plugin"]')) {
       return {type: 'PDF'};
     }
+    return null;
   }
 
   function detectFirefoxPDFViewer() {
@@ -43,6 +44,7 @@ function detectContentType(document_) {
     if (document_.baseURI.indexOf('resource://pdf.js') === 0) {
       return {type: 'PDF'};
     }
+    return null;
   }
 
   var detectFns = [detectChromePDFViewer, detectFirefoxPDFViewer];

--- a/src/common/hypothesis-chrome-extension.js
+++ b/src/common/hypothesis-chrome-extension.js
@@ -253,13 +253,14 @@ function HypothesisChromeExtension(dependencies) {
           }
           state.errorTab(tab.id, err);
         });
-    }
-    else if (state.isTabInactive(tab.id) && isInstalled) {
+    } else if (state.isTabInactive(tab.id) && isInstalled) {
       return sidebar.removeFromTab(tab).then(function () {
         state.setState(tab.id, {
           extensionSidebarInstalled: false,
         });
       });
+    } else {
+      return Promise.resolve();
     }
   }
 

--- a/src/common/hypothesis-chrome-extension.js
+++ b/src/common/hypothesis-chrome-extension.js
@@ -230,7 +230,7 @@ function HypothesisChromeExtension(dependencies) {
       });
 
       var config = {
-        annotations: state.getState(tab.id).directLinkedAnnotation
+        annotations: state.getState(tab.id).directLinkedAnnotation,
       };
 
       return sidebar.injectIntoTab(tab, config)

--- a/src/common/install.js
+++ b/src/common/install.js
@@ -58,7 +58,7 @@ function onInstalled(installDetails) {
   // This is intended to be a temporary fix only.
   var details = {
     primaryPattern: 'https://hypothes.is/*',
-    setting: 'allow'
+    setting: 'allow',
   };
   chrome.contentSettings.cookies.set(details);
   chrome.contentSettings.images.set(details);

--- a/src/common/sidebar-injector.js
+++ b/src/common/sidebar-injector.js
@@ -162,20 +162,20 @@ function SidebarInjector(chromeTabs, dependencies) {
     return canInjectScript(tab.url).then(function (canInject) {
       if (canInject) {
         return executeScriptFn(tab.id, {
-            code: toIIFEString(detectContentType)
-          }).then(function (frameResults) {
-            var result = extractContentScriptResult(frameResults);
-            if (result) {
-              return result.type;
-            } else {
+          code: toIIFEString(detectContentType),
+        }).then(function (frameResults) {
+          var result = extractContentScriptResult(frameResults);
+          if (result) {
+            return result.type;
+          } else {
               // If the content script threw an exception,
               // frameResults may be null or undefined.
               //
               // In that case, fall back to guessing based on the
               // tab URL
-              return guessContentTypeFromURL(tab.url);
-            }
-          });
+            return guessContentTypeFromURL(tab.url);
+          }
+        });
       } else {
         // We cannot inject a content script in order to determine the
         // file type, so fall back to a URL-based mechanism
@@ -193,7 +193,7 @@ function SidebarInjector(chromeTabs, dependencies) {
   }
 
   function isFileURL(url) {
-    return url.indexOf("file:") === 0;
+    return url.indexOf('file:') === 0;
   }
 
   function isSupportedURL(url) {

--- a/src/common/sidebar-injector.js
+++ b/src/common/sidebar-injector.js
@@ -36,7 +36,7 @@ function addJSONScriptTagFn(name, content) {
  *
  * See https://developer.chrome.com/extensions/tabs#method-executeScript
  *
- * @param {Array<any>} result
+ * @param {Array<any>?} result
  */
 function extractContentScriptResult(result) {
   if (Array.isArray(result) && result.length > 0) {
@@ -46,7 +46,7 @@ function extractContentScriptResult(result) {
     // an array from executeScript()
     return result;
   } else {
-    return;
+    return null;
   }
 }
 

--- a/src/common/tab-state.js
+++ b/src/common/tab-state.js
@@ -47,7 +47,7 @@ var DEFAULT_STATE = {
  * onchange     - A function that recieves onchange(tabId, current).
  */
 function TabState(initialState, onchange) {
-  var _this = this;
+  var self = this;
   var currentState;
 
   this.onchange = onchange || null;
@@ -132,8 +132,8 @@ function TabState(initialState, onchange) {
 
     currentState[tabId] = newState;
 
-    if (_this.onchange) {
-      _this.onchange(tabId, newState);
+    if (self.onchange) {
+      self.onchange(tabId, newState);
     }
   };
 

--- a/src/common/uri-info.js
+++ b/src/common/uri-info.js
@@ -15,15 +15,15 @@ function query(uri) {
   return fetch(settings.apiUrl + '/badge?uri=' + encodeUriQuery(uri),
                {credentials: 'include'})
     .then(function (res) {
-    return res.json();
-  }).then(function (data) {
-    if (typeof data.total !== 'number') {
-      throw new Error('Annotation count is not a number');
-    }
-    return data;
-  });
+      return res.json();
+    }).then(function (data) {
+      if (typeof data.total !== 'number') {
+        throw new Error('Annotation count is not a number');
+      }
+      return data;
+    });
 }
 
 module.exports = {
-  query: query
+  query: query,
 };

--- a/tests/bootstrap.js
+++ b/tests/bootstrap.js
@@ -1,3 +1,5 @@
+'use strict';
+
 window.EXTENSION_CONFIG = require('./settings.json');
 
 // Expose the sinon assertions.

--- a/tests/common/browser-action-test.js
+++ b/tests/common/browser-action-test.js
@@ -1,9 +1,9 @@
+'use strict';
+
 var assign = require('core-js/modules/$.object-assign');
 var proxyquire = require('proxyquire');
 
 describe('BrowserAction', function () {
-  'use strict';
-
   var BrowserAction = require('../../src/common/browser-action');
   var TabState = require('../../src/common/tab-state');
   var action;

--- a/tests/common/browser-action-test.js
+++ b/tests/common/browser-action-test.js
@@ -27,7 +27,7 @@ describe('BrowserAction', function () {
       },
       setBadgeBackgroundColor: function (options) {
         this.badgeColor = options.color;
-      }
+      },
     };
     action = new BrowserAction(fakeChromeBrowserAction);
   });
@@ -91,7 +91,7 @@ describe('BrowserAction', function () {
   });
 
   describe('annotation counts', function () {
-    it("sets the badge text", function() {
+    it('sets the badge text', function() {
       action.update(1, {
         state: TabState.states.INACTIVE,
         annotationCount: 23,
@@ -101,25 +101,25 @@ describe('BrowserAction', function () {
 
     it("sets the badge title when there's 1 annotation",
       function () {
-      action.update(1, {
-        state: TabState.states.INACTIVE,
-        annotationCount: 1,
-      });
-      assert.equal(fakeChromeBrowserAction.title,
+        action.update(1, {
+          state: TabState.states.INACTIVE,
+          annotationCount: 1,
+        });
+        assert.equal(fakeChromeBrowserAction.title,
         "There's 1 annotation on this page");
-    });
+      });
 
     it("sets the badge title when there's >1 annotation",
         function() {
-      action.update(1, {
-        state: TabState.states.INACTIVE,
-        annotationCount: 23,
-      });
-      assert.equal(fakeChromeBrowserAction.title,
-        "There are 23 annotations on this page");
-    });
+          action.update(1, {
+            state: TabState.states.INACTIVE,
+            annotationCount: 23,
+          });
+          assert.equal(fakeChromeBrowserAction.title,
+        'There are 23 annotations on this page');
+        });
 
-    it("does not set the badge text if there are 0 annotations", function() {
+    it('does not set the badge text if there are 0 annotations', function() {
       action.update(1, {
         state: TabState.states.INACTIVE,
         annotationCount: 0,
@@ -127,7 +127,7 @@ describe('BrowserAction', function () {
       assert.equal(fakeChromeBrowserAction.badgeText, '');
     });
 
-    it("does not set the badge title if there are 0 annotations", function() {
+    it('does not set the badge title if there are 0 annotations', function() {
       action.update(1, {
         state: TabState.states.INACTIVE,
         annotationCount: 0,

--- a/tests/common/errors-test.js
+++ b/tests/common/errors-test.js
@@ -12,7 +12,7 @@ describe('errors', function () {
     };
     errors = proxyquire('../../src/common/errors', {
       './raven': fakeRaven,
-      '@noCallThru': true
+      '@noCallThru': true,
     });
     sinon.stub(console, 'error');
   });

--- a/tests/common/help-page-test.js
+++ b/tests/common/help-page-test.js
@@ -18,7 +18,7 @@ describe('HelpPage', function () {
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
         openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#local-file'
+        url: 'CRX_PATH/help/index.html#local-file',
       });
     });
 
@@ -28,7 +28,7 @@ describe('HelpPage', function () {
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
         openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#no-file-access'
+        url: 'CRX_PATH/help/index.html#no-file-access',
       });
     });
 
@@ -38,7 +38,7 @@ describe('HelpPage', function () {
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
         openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#restricted-protocol'
+        url: 'CRX_PATH/help/index.html#restricted-protocol',
       });
     });
 
@@ -48,7 +48,7 @@ describe('HelpPage', function () {
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
         openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#blocked-site'
+        url: 'CRX_PATH/help/index.html#blocked-site',
       });
     });
 
@@ -58,7 +58,7 @@ describe('HelpPage', function () {
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
         openerTabId: 1,
-        url: 'CRX_PATH/help/index.html?message=Unexpected%20Error#other-error'
+        url: 'CRX_PATH/help/index.html?message=Unexpected%20Error#other-error',
       });
     });
   });
@@ -70,7 +70,7 @@ describe('HelpPage', function () {
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
         openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#local-file'
+        url: 'CRX_PATH/help/index.html#local-file',
       });
     });
   });
@@ -82,7 +82,7 @@ describe('HelpPage', function () {
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
         openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#no-file-access'
+        url: 'CRX_PATH/help/index.html#no-file-access',
       });
     });
   });
@@ -94,7 +94,7 @@ describe('HelpPage', function () {
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
         openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#restricted-protocol'
+        url: 'CRX_PATH/help/index.html#restricted-protocol',
       });
     });
   });

--- a/tests/common/help-page-test.js
+++ b/tests/common/help-page-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('HelpPage', function () {
   var errors = require('../../src/common/errors');
   var HelpPage = require('../../src/common/help-page');

--- a/tests/common/hypothesis-chrome-extension-test.js
+++ b/tests/common/hypothesis-chrome-extension-test.js
@@ -52,15 +52,15 @@ describe('HypothesisChromeExtension', function () {
       chromeTabs: fakeChromeTabs,
       chromeBrowserAction: fakeChromeBrowserAction,
       extensionURL: sandbox.stub(),
-      isAllowedFileSchemeAccess: sandbox.stub().yields(true)
+      isAllowedFileSchemeAccess: sandbox.stub().yields(true),
     });
   }
 
   beforeEach(function () {
     fakeChromeStorage = {
       sync: {
-        get: sandbox.stub().callsArgWith(1, {badge: true})
-      }
+        get: sandbox.stub().callsArgWith(1, {badge: true}),
+      },
     };
     fakeChromeTabs = {
       onCreated: new FakeListener(),
@@ -74,7 +74,7 @@ describe('HypothesisChromeExtension', function () {
       onClicked: new FakeListener(),
     };
     fakeHelpPage = {
-      showHelpForError: sandbox.spy()
+      showHelpForError: sandbox.spy(),
     };
     fakeTabStore = {
       all: sandbox.spy(),
@@ -120,7 +120,7 @@ describe('HypothesisChromeExtension', function () {
       './help-page': createConstructor(fakeHelpPage),
       './browser-action': createConstructor(fakeBrowserAction),
       './sidebar-injector': createConstructor(fakeSidebarInjector),
-      './errors': fakeErrors
+      './errors': fakeErrors,
     });
 
     ext = createExt();
@@ -139,7 +139,7 @@ describe('HypothesisChromeExtension', function () {
       savedState =  {
         1: {
           state: TabState.states.ACTIVE,
-        }
+        },
       };
       tabs.push({id: 1, url: 'http://example.com'});
       fakeChromeTabs.query = sandbox.stub().yields(tabs);
@@ -168,7 +168,7 @@ describe('HypothesisChromeExtension', function () {
       ext.firstRun({});
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
-        url: 'https://hypothes.is/welcome'
+        url: 'https://hypothes.is/welcome',
       });
     });
 
@@ -368,7 +368,7 @@ describe('HypothesisChromeExtension', function () {
     var injectErrorCases = [
       errors.LocalFileError,
       errors.NoFileAccessError,
-      errors.RestrictedProtocolError
+      errors.RestrictedProtocolError,
     ];
 
     injectErrorCases.forEach(function (ErrorType) {
@@ -452,7 +452,7 @@ describe('HypothesisChromeExtension', function () {
     beforeEach(function () {
       tab = {id: 1, status: 'complete'};
       fakeChromeTabs.get = sandbox.stub().yields(tab);
-      onChangeHandler = ext._onTabStateChange
+      onChangeHandler = ext._onTabStateChange;
     });
 
     it('updates the browser icon', function () {
@@ -512,7 +512,7 @@ describe('HypothesisChromeExtension', function () {
       fakeChromeTabs.get = sandbox.stub().yields({
         id: 1,
         status: 'complete',
-      })
+      });
       onTabStateChange(tabStates.INACTIVE, tabStates.ACTIVE);
       assert.calledWith(fakeSidebarInjector.removeFromTab, tab);
     });

--- a/tests/common/sidebar-injector-test.js
+++ b/tests/common/sidebar-injector-test.js
@@ -77,7 +77,7 @@ describe('SidebarInjector', function () {
       isAllowedFileSchemeAccess: fakeFileAccess,
       extensionURL: sinon.spy(function (path) {
         return EXTENSION_BASE_URL + path;
-      })
+      }),
     });
   });
 
@@ -99,18 +99,18 @@ describe('SidebarInjector', function () {
         var spy = fakeChromeTabs.executeScript;
         return toResult(injector.injectIntoTab({id: 1, url: url}))
           .then(function (result) {
-          assert.ok(result.error);
-          assert.instanceOf(result.error, errors.RestrictedProtocolError);
-          assert.notCalled(spy);
-        });
+            assert.ok(result.error);
+            assert.instanceOf(result.error, errors.RestrictedProtocolError);
+            assert.notCalled(spy);
+          });
       });
     });
 
     it('succeeds if the tab is already displaying the embedded PDF viewer', function () {
-        var url = PDF_VIEWER_BASE_URL +
+      var url = PDF_VIEWER_BASE_URL +
           encodeURIComponent('http://origin/foo.pdf');
-        return injector.injectIntoTab({id: 1, url: url});
-      }
+      return injector.injectIntoTab({id: 1, url: url});
+    }
     );
 
     describe('when viewing a remote PDF', function () {
@@ -121,7 +121,7 @@ describe('SidebarInjector', function () {
         var spy = fakeChromeTabs.update.yields({tab: 1});
         return injector.injectIntoTab({id: 1, url: url}).then(function() {
           assert.calledWith(spy, 1, {
-            url: PDF_VIEWER_BASE_URL + encodeURIComponent(url)
+            url: PDF_VIEWER_BASE_URL + encodeURIComponent(url),
           });
         });
       });
@@ -132,10 +132,10 @@ describe('SidebarInjector', function () {
         var hash = '#annotations:456';
         return injector.injectIntoTab({id: 1, url: url + hash})
           .then(function () {
-          assert.calledWith(spy, 1, {
-            url: PDF_VIEWER_BASE_URL + encodeURIComponent(url) + hash,
+            assert.calledWith(spy, 1, {
+              url: PDF_VIEWER_BASE_URL + encodeURIComponent(url) + hash,
+            });
           });
-        });
       });
     });
 
@@ -146,7 +146,7 @@ describe('SidebarInjector', function () {
 
         return injector.injectIntoTab({id: 1, url: url}).then(function() {
           assert.calledWith(spy, 1, {
-            file: sinon.match('/public/embed.js')
+            file: sinon.match('/public/embed.js'),
           });
         });
       });
@@ -156,9 +156,9 @@ describe('SidebarInjector', function () {
         var url = 'http://example.com';
         return toResult(injector.injectIntoTab({id: 1, url: url}))
           .then(function (result) {
-          assert.ok(result.error);
-          assert.instanceOf(result.error, errors.AlreadyInjectedError);
-        });
+            assert.ok(result.error);
+            assert.instanceOf(result.error, errors.AlreadyInjectedError);
+          });
       });
 
       it('injects config options into the page', function () {
@@ -186,7 +186,7 @@ describe('SidebarInjector', function () {
             function () {
               assert.called(spy);
               assert.calledWith(spy, 1, {
-                url: PDF_VIEWER_BASE_URL + encodeURIComponent('file:///foo.pdf')
+                url: PDF_VIEWER_BASE_URL + encodeURIComponent('file:///foo.pdf'),
               });
             }
           );
@@ -210,17 +210,17 @@ describe('SidebarInjector', function () {
         });
       });
 
-    describe('when viewing a local HTML file', function () {
-      it('returns an error', function () {
-        var url = 'file://foo.html';
-        var promise = injector.injectIntoTab({id: 1, url: url});
-        return toResult(promise).then(function (result) {
-          assert.instanceOf(result.error, errors.LocalFileError);
+      describe('when viewing a local HTML file', function () {
+        it('returns an error', function () {
+          var url = 'file://foo.html';
+          var promise = injector.injectIntoTab({id: 1, url: url});
+          return toResult(promise).then(function (result) {
+            assert.instanceOf(result.error, errors.LocalFileError);
+          });
         });
       });
     });
   });
-});
 
   describe('.removeFromTab', function () {
     it('bails early when trying to unload a chrome url', function () {
@@ -251,7 +251,7 @@ describe('SidebarInjector', function () {
           encodeURIComponent('http://example.com/foo.pdf') + '#foo';
         return injector.removeFromTab({id: 1, url: url}).then(function () {
           assert.calledWith(spy, 1, {
-            url: 'http://example.com/foo.pdf#foo'
+            url: 'http://example.com/foo.pdf#foo',
           });
         });
       });
@@ -262,7 +262,7 @@ describe('SidebarInjector', function () {
           encodeURIComponent('http://example.com/foo.pdf') + '#annotations:456';
         return injector.removeFromTab({id: 1, url: url}).then(function () {
           assert.calledWith(spy, 1, {
-            url: 'http://example.com/foo.pdf'
+            url: 'http://example.com/foo.pdf',
           });
         });
       });
@@ -273,7 +273,7 @@ describe('SidebarInjector', function () {
         isAlreadyInjected = true;
         return injector.removeFromTab({id: 1, url: 'http://example.com/foo.html'}).then(function () {
           assert.calledWith(fakeChromeTabs.executeScript, 1, {
-            file: sinon.match('/lib/destroy.js')
+            file: sinon.match('/lib/destroy.js'),
           });
         });
       });

--- a/tests/common/tab-state-test.js
+++ b/tests/common/tab-state-test.js
@@ -13,7 +13,7 @@ describe('TabState', function () {
   beforeEach(function () {
     onChange = sinon.spy();
     state = new TabState({
-      1: {state: states.ACTIVE}
+      1: {state: states.ACTIVE},
     }, onChange);
   });
 
@@ -133,7 +133,7 @@ describe('TabState', function () {
       var TabState = proxyquire('../../src/common/tab-state', {
         './uri-info': {
           query: queryStub,
-        }
+        },
       });
       var tabState = new TabState({1: {state: states.ACTIVE}});
       return tabState.updateAnnotationCount(1, 'foobar.com')
@@ -148,7 +148,7 @@ describe('TabState', function () {
       var TabState = proxyquire('../../src/common/tab-state', {
         './uri-info': {
           query: queryStub,
-        }
+        },
       });
       var tabState = new TabState({1: {
         state: states.ACTIVE,

--- a/tests/common/tab-state-test.js
+++ b/tests/common/tab-state-test.js
@@ -78,7 +78,7 @@ describe('TabState', function () {
   describe('.clearTab', function () {
     it('removes the state for the tab id provided', function () {
       state.clearTab(1);
-      assert.equal(state.isTabActive(1), false), 'expected isTabActive to return false';
+      assert.equal(state.isTabActive(1), false, 'expected isTabActive to return false');
       assert.equal(state.isTabInactive(1), true, 'expected isTabInactive to return true');
       assert.equal(state.isTabErrored(1), false, 'expected isTabInactive to return false');
     });

--- a/tests/common/tab-store-test.js
+++ b/tests/common/tab-store-test.js
@@ -1,6 +1,6 @@
-describe('TabStore', function () {
-  'use strict';
+'use strict';
 
+describe('TabStore', function () {
   var TabStore = require('../../src/common/tab-store');
   var store;
   var fakeLocalStorage;

--- a/tests/common/tab-store-test.js
+++ b/tests/common/tab-store-test.js
@@ -18,7 +18,7 @@ describe('TabStore', function () {
   describe('.get', function () {
     beforeEach(function () {
       fakeLocalStorage.data.state = JSON.stringify({
-        1: {state: 'active'}
+        1: {state: 'active'},
       });
       store.reload();
     });
@@ -36,7 +36,7 @@ describe('TabStore', function () {
 
     it('converts state-string keys to objects', function () {
       fakeLocalStorage.data.state = JSON.stringify({
-        1: 'active'
+        1: 'active',
       });
       store.reload();
       assert.deepEqual(store.get(1), { state: 'active' });
@@ -46,7 +46,7 @@ describe('TabStore', function () {
   describe('.set', function () {
     it('inserts a JSON string into the store for the tab id', function () {
       var expected = JSON.stringify({
-        1: { state: 'active' }
+        1: { state: 'active' },
       });
       store.set(1, { state: 'active' });
       assert.calledWith(fakeLocalStorage.setItem, 'state', expected);
@@ -64,7 +64,7 @@ describe('TabStore', function () {
 
     it('overrides existing properties on the serialized object', function () {
       var expected = JSON.stringify({
-        1: {state: 'inactive'}
+        1: {state: 'inactive'},
       });
       store.set(1, { state: 'active' });
       store.set(1, { state: 'inactive' });

--- a/tests/common/uri-info-test.js
+++ b/tests/common/uri-info-test.js
@@ -14,7 +14,7 @@ describe('UriInfo.query', function () {
       Promise.resolve(
         new window.Response('{"total": 1}', {
           status: 200,
-          headers: {}
+          headers: {},
         })
       )
     );
@@ -39,11 +39,11 @@ describe('UriInfo.query', function () {
   it('urlencodes the URL appropriately', function () {
     return toResult(uriInfo.query('http://foo.com?bar=baz qüx'))
       .then(function () {
-      assert.equal(fetch.callCount, 1);
-      assert.equal(
+        assert.equal(fetch.callCount, 1);
+        assert.equal(
         fetch.lastCall.args[0],
         badgeURL + '?uri=http%3A%2F%2Ffoo.com%3Fbar%3Dbaz+q%C3%BCx');
-    });
+      });
   });
 
   var INVALID_RESPONSE_FIXTURES = [

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -13,7 +13,7 @@ module.exports = function(config) {
       'browserify',
       'mocha',
       'chai',
-      'sinon'
+      'sinon',
     ],
 
 
@@ -83,6 +83,6 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false
+    singleRun: false,
   });
 };

--- a/tools/.eslintrc
+++ b/tools/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "node": true
+  },
+  "rules": {
+    "no-console": "off"
+  }
+}

--- a/tools/settings.js
+++ b/tools/settings.js
@@ -44,7 +44,7 @@ function getVersion(buildType) {
 }
 
 if (process.argv.length !== 3) {
-  console.error("Usage: %s <settings.json>", path.basename(process.argv[1]));
+  console.error('Usage: %s <settings.json>', path.basename(process.argv[1]));
   process.exit(1);
 }
 

--- a/tools/template-context-app.js
+++ b/tools/template-context-app.js
@@ -47,7 +47,7 @@ function appSettings(settings) {
 }
 
 if (process.argv.length !== 3) {
-  console.error("Usage: %s <settings.json>", path.basename(process.argv[1]));
+  console.error('Usage: %s <settings.json>', path.basename(process.argv[1]));
   process.exit(1);
 }
 

--- a/tools/template-context-settings.js
+++ b/tools/template-context-settings.js
@@ -24,7 +24,7 @@ function extensionSettings(settings) {
 }
 
 if (process.argv.length !== 3) {
-  console.error("Usage: %s <settings.json>", path.basename(process.argv[1]));
+  console.error('Usage: %s <settings.json>', path.basename(process.argv[1]));
   process.exit(1);
 }
 


### PR DESCRIPTION
This sets up ESLint using the same shared config as the `client` and `h` repos.

There are three commits in this PR:

- The first adds the ESLint config and a `make lint` task
- The second fixes up trivial issues using `eslint . --fix`
- The third includes manual fixes for the remaining issues, which included several missing function returns, missing or misplaced 'use strict' and parenthesis in the wrong place in a function call