### PR TITLE
Add a script that creates and pushes a new tag

### DIFF
--- a/tools/release-it
+++ b/tools/release-it
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Create a new tag release of the browser extension.
+#
+# The current workflow for a browser extension release is:
+#
+#  1. Update the 'hypothesis' package dependency to the latest version
+#  2. Update the package version to match the 'hypothesis' client package
+#     version
+#  3. Tag and push a new release of the browser-extension repo using this
+#     script
+#  4. When the Travis CI builds for the tag complete, upload the
+#     extension to the Chrome Web Store
+
+set -eu
+
+VERSION=$(node -e "console.log(require('./package.json').version)")
+TAG_NAME=v$VERSION
+
+git fetch --tags
+git tag --sign $TAG_NAME -m "Release $TAG_NAME"
+git push --follow-tags
+
+echo "$TAG_NAME has been tagged."
+echo "Wait for the build to complete at https://travis-ci.org/hypothesis/browser-extension"
+echo "and upload the Chrome extensions to the Chrome Web Store"


### PR DESCRIPTION
It serves mostly as documentation for the current release process and a reference for when we come to automate the process entirely in future.