### PR TITLE
Fix incorrect use assert.called()

### DIFF
--- a/tests/common/tab-store-test.js
+++ b/tests/common/tab-store-test.js
@@ -80,7 +80,7 @@ describe('TabStore', function () {
 
     it('removes a property from the serialized object', function () {
       store.unset(1);
-      assert.called(fakeLocalStorage.setItem, '{}');
+      assert.calledWith(fakeLocalStorage.setItem, 'state', '{}');
     });
   });
 


### PR DESCRIPTION
The current version of sinon reported an error due to incorrect use of `assert.called()` instead of `assert.calledWith()`