### PR TITLE
Use Node v6.2 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: '4.3'
+node_js: '6.2'
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
This keeps things consistent with the version of Node used by h:

    https://github.com/hypothesis/h/commit/cc71f6c571829344e1f50a05b33504a2d42725d4