### PR TITLE
Use service URL from settings to construct welcome page URL

### DIFF
--- a/src/common/hypothesis-chrome-extension.js
+++ b/src/common/hypothesis-chrome-extension.js
@@ -1,12 +1,13 @@
 'use strict';
 
-var annotationIDs = require('./annotation-ids');
-var errors = require('./errors');
-var TabState = require('./tab-state');
 var BrowserAction = require('./browser-action');
 var HelpPage = require('./help-page');
 var SidebarInjector = require('./sidebar-injector');
+var TabState = require('./tab-state');
 var TabStore = require('./tab-store');
+var annotationIDs = require('./annotation-ids');
+var errors = require('./errors');
+var settings = require('./settings');
 
 var TAB_STATUS_LOADING = 'loading';
 var TAB_STATUS_COMPLETE = 'complete';
@@ -97,7 +98,7 @@ function HypothesisChromeExtension(dependencies) {
       return;
     }
 
-    chromeTabs.create({url: 'https://hypothes.is/welcome'}, function (tab) {
+    chromeTabs.create({url: settings.serviceUrl + 'welcome'}, function (tab) {
       state.activateTab(tab.id);
     });
   };

--- a/src/common/install.js
+++ b/src/common/install.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var HypothesisChromeExtension = require('./hypothesis-chrome-extension');
+var settings = require('./settings');
 
 var browserExtension = new HypothesisChromeExtension({
   chromeTabs: chrome.tabs,
@@ -20,7 +21,7 @@ if (chrome.runtime.onInstalled) {
   chrome.runtime.onInstalled.addListener(onInstalled);
 }
 
-// Respond to messages sent by the JavaScript from https://hpt.is.
+// Respond to messages sent by the JavaScript from https://hyp.is.
 // This is how it knows whether the user has this Chrome extension installed.
 if (chrome.runtime.onMessageExternal) {
   chrome.runtime.onMessageExternal.addListener(
@@ -57,7 +58,7 @@ function onInstalled(installDetails) {
   // See https://github.com/hypothesis/h/issues/634 for more info.
   // This is intended to be a temporary fix only.
   var details = {
-    primaryPattern: 'https://hypothes.is/*',
+    primaryPattern: settings.serviceUrl + '*',
     setting: 'allow',
   };
   chrome.contentSettings.cookies.set(details);

--- a/tests/common/hypothesis-chrome-extension-test.js
+++ b/tests/common/hypothesis-chrome-extension-test.js
@@ -121,6 +121,9 @@ describe('HypothesisChromeExtension', function () {
       './browser-action': createConstructor(fakeBrowserAction),
       './sidebar-injector': createConstructor(fakeSidebarInjector),
       './errors': fakeErrors,
+      './settings': {
+        serviceUrl: 'https://hypothes.is/',
+      },
     });
 
     ext = createExt();

--- a/tests/common/install-test.js
+++ b/tests/common/install-test.js
@@ -4,10 +4,10 @@ var proxyquire = require('proxyquire');
 
 var extension;
 
-function FakeHypothesisChromeExtension(args) {
+function FakeHypothesisChromeExtension(deps) {
   extension = this; // eslint-disable-line consistent-this
 
-  this.args = args;
+  this.deps = deps;
   this.listen = sinon.stub();
   this.install = sinon.stub();
   this.firstRun = sinon.stub();

--- a/tests/common/install-test.js
+++ b/tests/common/install-test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var proxyquire = require('proxyquire');
+
+var extension;
+
+function FakeHypothesisChromeExtension(args) {
+  extension = this; // eslint-disable-line consistent-this
+
+  this.args = args;
+  this.listen = sinon.stub();
+  this.install = sinon.stub();
+  this.firstRun = sinon.stub();
+}
+
+function eventListenerStub() {
+  return {
+    addListener: sinon.stub(),
+  };
+}
+
+describe('install', function () {
+  var origChrome;
+  var fakeChrome;
+
+  beforeEach(function () {
+    fakeChrome = {
+      tabs: {},
+      browserAction: {},
+      storage: {},
+      extension: {
+        getURL: sinon.stub(),
+        isAllowedFileSchemeAccess: sinon.stub(),
+      },
+      contentSettings: {
+        cookies: { set: sinon.stub() },
+        images: { set: sinon.stub() },
+        javascript: { set: sinon.stub() },
+      },
+      runtime: {
+        requestUpdateCheck: sinon.stub(),
+        onInstalled: eventListenerStub(),
+        onMessageExternal: eventListenerStub(),
+        onUpdateAvailable: eventListenerStub(),
+      },
+      management: {
+        getSelf: function (cb) {
+          cb({installType: 'normal', id: '1234'});
+        },
+      },
+    };
+
+    origChrome = window.chrome;
+    window.chrome = fakeChrome;
+
+    proxyquire('../../src/common/install', {
+      './hypothesis-chrome-extension': FakeHypothesisChromeExtension,
+      './settings': {
+        serviceUrl: 'https://hypothes.is/',
+      },
+    });
+  });
+
+  afterEach(function () {
+    window.chrome = origChrome;
+  });
+
+  context('when the extension is installed', function () {
+    function triggerInstallEvent() {
+      var cb = fakeChrome.runtime.onInstalled.addListener.args[0][0];
+      cb({reason: 'install'});
+    }
+
+    it("calls the extension's first run hook", function () {
+      triggerInstallEvent();
+      assert.calledWith(extension.firstRun, {id: '1234', installType: 'normal'});
+    });
+
+    it('enables extension to set cookies for service domain', function () {
+      triggerInstallEvent();
+      assert.calledWith(fakeChrome.contentSettings.cookies.set, {
+        primaryPattern: 'https://hypothes.is/*',
+        setting: 'allow',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Use the service URL from the extension's settings to construct the URL
for the '/welcome' page and the URL pattern that allows requests made by
the extension to set cookies for the Hypothesis domain.

Previously both of these were hardcoded to 'https://hypothes.is', an
issue that was noticed when testing deployment of the service to
Skyliner under a different domain.

----

Manual testing:

1. Remove the existing unpacked extension (if any) locally
2. Change the domain for the extension in `settings/chrome-prod.json` to a different domain (eg. 'https://next.hypothes.is/' - note the empty '/' path here is part of the service URL) and build the extension for production.
3. Re-add the unpacked extension and verify that after installation, a tab is opened at `<service domain>welcome`