### PR TITLE
Update class name for config script tag in sidebar app

### DIFF
--- a/src/client/app.html.mustache
+++ b/src/client/app.html.mustache
@@ -13,7 +13,10 @@
   <body>
     <hypothesis-app></hypothesis-app>
 
-    <script class="js-hypothesis-settings" type="application/json">
+    {{! The `js-hypothesis-settings` class can be removed once the client is
+        updated to include https://github.com/hypothesis/client/pull/243
+    }}
+    <script class="js-hypothesis-config js-hypothesis-settings" type="application/json">
     {{&settings}}
     </script>
 


### PR DESCRIPTION
**This needs to be merged _before_ an extension containing https://github.com/hypothesis/client/pull/243 is released.**

https://github.com/hypothesis/client/pull/243 changes the client to use
the same class name, `js-hypothesis-config`, for config script tags in
both the sidebar app and host page.

This updates the extension's app.html template to use the expected name.