### PR TITLE
Support setting the 4th component of the extension version

### DIFF
--- a/tools/settings.js
+++ b/tools/settings.js
@@ -20,8 +20,8 @@ process.stdout.on('error', err => {
  * rules:
  *
  * - If buildType is 'production' and the git state is not clean, throw an error
- * - Set the version number to X.Y.Z.W, where X.Y.Z is the last tagged release
- *   and W is the number of commits since that release.
+ * - Set the version number to X.Y.Z.W, where the version is taken from the last
+ *   tagged release.
  * - If the buildType is 'production', set the version name to "Official Build",
  *   otherwise set it to a string of the form "gXXXXXXX[.dirty]" to reflect the
  *   exact commit and state of the repository.
@@ -33,7 +33,10 @@ function getVersion(buildType) {
     throw new Error('cannot create production build with dirty git state!');
   }
 
-  const version = `${gitInfo.semver}.${gitInfo.distance}`;
+  // We extract the version rather than using `gitInfo.semver` here because the
+  // tag may include a 4th version component which is not allowed in semver,
+  // but is allowed in Chrome/Firefox/Edge extension versions.
+  const [, version] = gitInfo.tag.match(/v([0-9.]+)/);
   let versionName = 'Official Build';
 
   if (buildType !== 'production') {


### PR DESCRIPTION
We use the first three components of the extension version for the
client version. It is useful to be able to set the 4th component [1] for
releases with extension-only changes.

We cannot set the 4th component in the package.json version field, but
we can set it in the tag name which is what is actually used to generate
the extension version.

This commit removes the auto-generated 4th component from the extension
version and instead extracts it from the tag version. With this change,
extension only releases can be made by leaving the version unchanged in
`package.json` but creating a signed tag such as `v0.59.0.1`.

[1] Chrome/Firefox/Edge extension versions may have up to 4 components.
    Any that are not set default to 0.