### PR TITLE
Automate upload of Chrome extensions to Chrome Web Store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,9 @@ addons:
     paths:
       # Upload all built extension packages
       - $(ls dist/*.zip dist/*.xpi | tr "\n" ":")
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: ./tools/deploy
+  on:
+    branch: master

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "browserify": "^13.0.0",
     "chai": "^3.5.0",
     "check-dependencies": "^0.12.0",
+    "chrome-webstore-upload-cli": "^1.1.1",
     "core-js": "^1.2.5",
     "diff": "^2.2.2",
     "eslint": "^3.2.0",

--- a/tools/chrome-webstore-refresh-token
+++ b/tools/chrome-webstore-refresh-token
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -eu
+
+# This script is a helper for generating the refresh token used to automate
+# upload and publishing of Chrome extensions to the Chrome Web Store. 
+#
+# 1. Read the guide at https://github.com/DrewML/chrome-webstore-upload/blob/master/How%20to%20generate%20Google%20API%20keys.md
+#
+#    The Client ID and Client Secret can be found/generated under the 'Client
+#    Chrome Extension' project in the 'hypothes.is' organization at
+#    https://console.developers.google.com
+#
+# 2. After the step in the above guide that gives you an auth code in the
+#    browser, run this script with the auth code to get a refresh token:
+#
+#    ./tools/chrome-webstore-refresh-token $AUTH_CODE
+#
+# 3. Copy the 'refresh_token' value and add it to the Travis config as the
+#    CHROME_WEBSTORE_REFRESH_TOKEN env var
+
+AUTH_CODE=$1
+
+if [ -z "$AUTH_CODE" ]; then
+  echo "Auth code not specified."
+fi
+
+curl "https://accounts.google.com/o/oauth2/token" -d "client_id=$CHROME_WEBSTORE_CLIENT_ID&client_secret=$CHROME_WEBSTORE_CLIENT_SECRET&code=$AUTH_CODE&grant_type=authorization_code&redirect_uri=urn:ietf:wg:oauth:2.0:oob"
+

--- a/tools/deploy
+++ b/tools/deploy
@@ -3,6 +3,7 @@
 set -eu
 
 CHROME_STAGE_EXT_ID=iahhmhdkmkifclacffbofcnmgkpalpoj
+CHROME_PROD_EXT_ID=bjfhmglciegochdpefhhlphglcehbmek
 
 # Upload and publish stage extension
 CHROME_STAGE_EXT_ARCHIVE=dist/*-chrome-stage.zip
@@ -18,4 +19,18 @@ fi
   --client-secret $CHROME_WEBSTORE_CLIENT_SECRET \
   --refresh-token $CHROME_WEBSTORE_REFRESH_TOKEN \
   --auto-publish
+
+# Upload (but do not publish) prod extension
+CHROME_PROD_EXT_ARCHIVE=dist/*-chrome-prod.zip
+if [ ! -f $CHROME_PROD_EXT_ARCHIVE ]; then
+  echo "Chrome prod extension has not been built."
+  exit 1
+fi
+
+./node_modules/.bin/webstore upload \
+  --source $CHROME_PROD_EXT_ARCHIVE \
+  --extension-id $CHROME_PROD_EXT_ID \
+  --client-id $CHROME_WEBSTORE_CLIENT_ID \
+  --client-secret $CHROME_WEBSTORE_CLIENT_SECRET \
+  --refresh-token $CHROME_WEBSTORE_REFRESH_TOKEN \
 

--- a/tools/deploy
+++ b/tools/deploy
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -eu
+
+CHROME_STAGE_EXT_ID=iahhmhdkmkifclacffbofcnmgkpalpoj
+
+# Upload and publish stage extension
+CHROME_STAGE_EXT_ARCHIVE=dist/*-chrome-stage.zip
+if [ ! -f $CHROME_STAGE_EXT_ARCHIVE ]; then
+  echo "Chrome stage extension has not been built."
+  exit 1
+fi
+
+./node_modules/.bin/webstore upload \
+  --source $CHROME_STAGE_EXT_ARCHIVE \
+  --extension-id $CHROME_STAGE_EXT_ID \
+  --client-id $CHROME_WEBSTORE_CLIENT_ID \
+  --client-secret $CHROME_WEBSTORE_CLIENT_SECRET \
+  --refresh-token $CHROME_WEBSTORE_REFRESH_TOKEN \
+  --auto-publish
+


### PR DESCRIPTION
Use the [chrome-webstore-upload-cli](https://github.com/DrewML/chrome-webstore-upload-cli) tool to upload Chrome extensions to the Chrome Web Store automatically on pushes to master.

The stage extension is uploaded and published automatically. The prod extension is uploaded so the Chrome Web Store can start performing malware checks but not actually published. This gives us a chance to do any manual testing we want with the stage extension before hitting the Publish button in the Chrome Web Store's Developer Dashboard.

CHROME_WEBSTORE_{CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN} env vars have been added to the Travis CI config. Generating the refresh token is a PITA, so I have added a script to document and assist with the process if we ever need to do it again.