### PR TITLE
Change js-hypothesis-settings -> config

### DIFF
--- a/src/client/app.html.mustache
+++ b/src/client/app.html.mustache
@@ -13,7 +13,7 @@
   <body>
     <hypothesis-app></hypothesis-app>
 
-    <script class="js-hypothesis-settings" type="application/json">
+    <script class="js-hypothesis-config" type="application/json">
     {{&settings}}
     </script>
 


### PR DESCRIPTION
A client commit <https://github.com/hypothesis/client/commit/68be70df5ac05ee5ad9411140f03c13aa0d862b3>
changed the "js-hypothesis-settings" CSS class name to "js-hypothesis-config",
which breaks the Chrome extension because it still uses
"js-hypothesis-settings". Fix the Chrome extension to use
"js-hypothesis-config" as well so it'll work with new versions of the
client.