### PR TITLE
Add some npm link tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,28 +71,12 @@ documentation for instructions on building the client in a development
 environment.
 
 **Tip**: If you get a **permission denied** error when running `npm link`
-you probably need to tell npm to install packages into a directory in your home
-directory that you have permission to write to. On linux:
-
-```sh
-npm config set prefix /home/<YOUR_USERNAME>/npm
-```
-
-On macOS:
-
-```sh
-npm config set prefix /Users/<YOUR_USERNAME>/npm
-```
-
-`npm` will now install executable files into `$HOME/npm/bin`, so add that
-directory to your `$PATH`.
+you probably need to fix npm's permissions. See
+[Fixing npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions).
 
 **Tip**: To **unlink** your dev browser extension from your dev client run
-`npm unlink hypothesis` in your browser extension directory:
-
-```sh
-npm unlink hypothesis
-```
+`npm unlink hypothesis` in your browser extension directory
+(see the [npm uninstall docs](https://docs.npmjs.com/cli/uninstall)).
 
 See [Building the extension](docs/building.md) for more information.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,30 @@ built client from the client repository. Please consult the client's
 documentation for instructions on building the client in a development
 environment.
 
+**Tip**: If you get a **permission denied** error when running `npm link`
+you probably need to tell npm to install packages into a directory in your home
+directory that you have permission to write to. On linux:
+
+```sh
+npm config set prefix /home/<YOUR_USERNAME>/npm
+```
+
+On macOS:
+
+```sh
+npm config set prefix /Users/<YOUR_USERNAME>/npm
+```
+
+`npm` will now install executable files into `$HOME/npm/bin`, so add that
+directory to your `$PATH`.
+
+**Tip**: To **unlink** your dev browser extension from your dev client run
+`npm unlink hypothesis` in your browser extension directory:
+
+```sh
+npm unlink hypothesis
+```
+
 See [Building the extension](docs/building.md) for more information.
 
 [client]: https://github.com/hypothesis/client/


### PR DESCRIPTION
Add a couple of tips on using `npm link`. These come from <http://h.readthedocs.io/en/latest/developing/install/client/> which is going to be deleted