### PR TITLE
Don't do git checkout or pull from a script

### DIFF
--- a/tools/update-client
+++ b/tools/update-client
@@ -13,9 +13,17 @@ if ! git diff --quiet HEAD ; then
   exit 1
 fi
 
-# Update checkout
-git checkout master
-git pull
+# Fetch commits from main repo and write commit ref to `.git/FETCH_HEAD`
+git fetch --quiet https://github.com/hypothesis/browser-extension.git master
+
+# Check that HEAD is the latest commit on the
+# github.com/hypothesis/browser-extension repo.
+remote_head=$(cat .git/FETCH_HEAD | cut -f1)
+local_head=$(git rev-parse HEAD)
+if [ $remote_head != $local_head ]; then
+  echo "Current commit does not match head of hypothesis/browser-extension.git:master"
+  exit 1
+fi
 
 # Update client to latest version on npm
 npm install --save-dev hypothesis@$LATEST_CLIENT_VERSION


### PR DESCRIPTION
The docs for releasing a Chrome extension say to checkout and pull the
latest master branch manually.

The script as its currently written assumes that the user's master
branch is setup as a tracking branch of the hypothesis organization's
master branch on GitHub, which while a common setup isn't always the
case (it's not the case for me, for example, so the script crashes for me).

For example it's common to fork a github repo and then clone your fork.