### PR TITLE
Fix postversion git push command

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "whatwg-fetch": "^0.10.1"
   },
   "scripts": {
-    "postversion": "git push --follow-tags",
+    "postversion": "git push https://github.com/hypothesis/browser-extension.git master:master --follow-tags",
     "preversion": "npm run test",
     "test": "karma start tests/karma.config.js --single-run"
   }


### PR DESCRIPTION
Fix the `git push` command that `npm version` runs after making a new
version.

The command as it was assumed that the user's git repo's `origin` remote
is https://github.com/hypothesis/browser-extension, which is not always
the case. For example it's common to fork an open source repo to another
github (or bitbucket etc) account and then clone your own fork locally.