### PR TITLE
Fix client failing to load in Firefox WebExtension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ build/client/build: node_modules/hypothesis/build/manifest.json
 	@# We can't leave the client manifest in the build or the Chrome Web Store
 	@# will complain.
 	rm $@/manifest.json
+	@# Add a serializable expression as the last statement in the boot script
+	@# bundle, otherwise Firefox will complain if attempting to execute the Browserify
+	@# bundle that the "Script returned non-structured-clonable data"
+	echo "null" >> build/client/build/boot.js
+
 build/client/app.html: src/client/app.html.mustache build/client build/.settings.json
 	tools/template-context-app.js build/.settings.json | $(MUSTACHE) - $< >$@
 build/settings-data.js: src/chrome/settings-data.js.mustache build/client build/.settings.json

--- a/src/common/browser-name.js
+++ b/src/common/browser-name.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * Returns the name of the current browser.
+ *
+ * @return {'chrome'|'firefox'}
+ */
+function browserName() {
+  if (window.browser) {
+    return 'firefox';
+  } else {
+    return 'chrome';
+  }
+}
+
+module.exports = browserName;

--- a/src/common/help-page.js
+++ b/src/common/help-page.js
@@ -63,8 +63,9 @@ function HelpPage(chromeTabs, extensionURL, browserName_) {
       url:  extensionURL('/help/index.html' + params + '#' + helpSection),
     };
 
+    // Add `openerTabId` property to associate the help page tab with the
+    // current tab. This property is not supported in Firefox.
     if (browserName_() !== 'firefox') {
-      // We are in Firefox, which does not support the `openerTabId` parameter.
       tabOpts.openerTabId = tab.id;
     }
 

--- a/src/common/help-page.js
+++ b/src/common/help-page.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var browserName = require('./browser-name');
 var errors = require('./errors');
 
 /* A controller for displaying help pages. These are bound to extension
@@ -10,7 +11,9 @@ var errors = require('./errors');
  *   to the file inside the chrome extension. See:
  *   https://developer.chrome.com/extensions/extension#method-getURL
  */
-function HelpPage(chromeTabs, extensionURL) {
+function HelpPage(chromeTabs, extensionURL, browserName_) {
+  browserName_ = browserName_ || browserName;
+
   /* Accepts an instance of errors.ExtensionError and displays an appropriate
    * help page if one exists.
    *
@@ -55,11 +58,17 @@ function HelpPage(chromeTabs, extensionURL) {
       params = '?message=' + encodeURIComponent(error.message);
     }
 
-    chromeTabs.create({
+    var tabOpts = {
       index: tab.index + 1,
       url:  extensionURL('/help/index.html' + params + '#' + helpSection),
-      openerTabId: tab.id,
-    });
+    };
+
+    if (browserName_() !== 'firefox') {
+      // We are in Firefox, which does not support the `openerTabId` parameter.
+      tabOpts.openerTabId = tab.id;
+    }
+
+    chromeTabs.create(tabOpts);
   }
 }
 

--- a/src/common/hypothesis-chrome-extension.js
+++ b/src/common/hypothesis-chrome-extension.js
@@ -274,6 +274,12 @@ function HypothesisChromeExtension(dependencies) {
   }
 
   function updateAnnotationCountIfEnabled(tabId, url) {
+    if (!chromeStorage.sync) {
+      // Firefox < 53 does not support `chrome.storage.sync`.
+      state.updateAnnotationCount(tabId, url);
+      return;
+    }
+
     chromeStorage.sync.get({
       badge: true,
     }, function (items) {

--- a/tests/common/help-page-test.js
+++ b/tests/common/help-page-test.js
@@ -3,14 +3,18 @@
 describe('HelpPage', function () {
   var errors = require('../../src/common/errors');
   var HelpPage = require('../../src/common/help-page');
+  var fakeBrowserName;
   var fakeChromeTabs;
+  var fakeExtensionURL;
   var help;
 
   beforeEach(function () {
+    fakeBrowserName = sinon.stub().returns('chrome');
     fakeChromeTabs = {create: sinon.stub()};
-    help = new HelpPage(fakeChromeTabs, function fakeExtensionURL(path) {
+    fakeExtensionURL = function (path) {
       return 'CRX_PATH' + path;
-    });
+    };
+    help = new HelpPage(fakeChromeTabs, fakeExtensionURL, fakeBrowserName);
   });
 
   describe('.showHelpForError', function () {
@@ -97,6 +101,19 @@ describe('HelpPage', function () {
         index: 2,
         openerTabId: 1,
         url: 'CRX_PATH/help/index.html#restricted-protocol',
+      });
+    });
+  });
+
+  context('in Firefox', function () {
+    it('does not set the "openerTabId" argument when creating a new tab', function () {
+      fakeBrowserName.returns('firefox');
+      var help = new HelpPage(fakeChromeTabs, fakeExtensionURL, fakeBrowserName);
+      help.showHelpForError({id: 1, index: 1}, new errors.LocalFileError('msg'));
+      assert.called(fakeChromeTabs.create);
+      assert.calledWith(fakeChromeTabs.create, {
+        index: 2,
+        url: 'CRX_PATH/help/index.html#local-file',
       });
     });
   });

--- a/tests/common/hypothesis-chrome-extension-test.js
+++ b/tests/common/hypothesis-chrome-extension-test.js
@@ -291,6 +291,33 @@ describe('HypothesisChromeExtension', function () {
         fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
         assert.equal(tabState[tab.id].state, TabState.states.ACTIVE);
       });
+
+      it('updates the badge count', function () {
+        var tab = createTab();
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
+        assert.calledWith(fakeTabState.updateAnnotationCount, tab.id, 'http://example.com/foo.html');
+      });
+
+      it('updates the badge count if "chrome.storage.sync" is not supported', function () {
+        var tab = createTab();
+        delete fakeChromeStorage.sync;
+
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
+
+        assert.calledWith(fakeTabState.updateAnnotationCount, tab.id, 'http://example.com/foo.html');
+      });
+
+      it('does not update the badge count if the option is disabled', function () {
+        var tab = createTab();
+        fakeChromeStorage.sync.get.callsArgWith(1, {badge: false});
+
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
+
+        assert.notCalled(fakeTabState.updateAnnotationCount);
+      });
     });
 
     describe('when a tab is replaced', function () {


### PR DESCRIPTION
This is a set of three fixes for the Firefox WebExtension which, together with https://github.com/hypothesis/client/pull/460 , enables the extension to work in the current stable version of Firefox (v51).

See individual commit messages for details.

**Steps to test:**

1. Checkout https://github.com/hypothesis/client/pull/460 in the client repo and build the client.
2. Checkout this PR in the browser-extension repo
3. Build the Firefox dev extension `make SETTINGS_FILE=settings/firefox-dev.json`, making sure that you are using the client build from (1)
4. In the stable version of Firefox, go to "about:debugging#addons", click "Load Temporary Addon" and select the "manifest.json" file from the "build" directory.