### PR TITLE
Add OAuth configuration to extension settings

### DIFF
--- a/settings/chrome-prod.json
+++ b/settings/chrome-prod.json
@@ -7,6 +7,9 @@
   "serviceUrl": "https://hypothes.is/",
   "websocketUrl": "wss://hypothes.is/ws",
 
+  "oauthClientId": "fd23fe2e-7792-11e7-8e16-23e47a1799d4",
+  "oauthEnabled": false,
+
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
   "googleAnalytics": "UA-26026798-5",
 

--- a/settings/chrome-stage.json
+++ b/settings/chrome-stage.json
@@ -7,6 +7,9 @@
   "serviceUrl": "https://qa.hypothes.is/",
   "websocketUrl": "wss://qa.hypothes.is/ws",
 
+  "oauthClientId": "da545114-7792-11e7-90b4-b35c52774c7d",
+  "oauthEnabled": false,
+
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
   "googleAnalytics": "UA-26026798-6",
 

--- a/settings/firefox-prod.json
+++ b/settings/firefox-prod.json
@@ -7,6 +7,9 @@
   "serviceUrl": "https://hypothes.is/",
   "websocketUrl": "wss://hypothes.is/ws",
 
+  "oauthClientId": "7fb28342-7793-11e7-90b5-7fed4053f592",
+  "oauthEnabled": false,
+
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
   "googleAnalytics": "UA-26026798-5",
 

--- a/settings/firefox-stage.json
+++ b/settings/firefox-stage.json
@@ -7,6 +7,9 @@
   "serviceUrl": "https://qa.hypothes.is/",
   "websocketUrl": "wss://qa.hypothes.is/ws",
 
+  "oauthClientId": "92b42e3c-7793-11e7-8e17-cb2151436a1f",
+  "oauthEnabled": false,
+
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
   "googleAnalytics": "UA-26026798-6",
 

--- a/tools/template-context-app.js
+++ b/tools/template-context-app.js
@@ -29,6 +29,10 @@ function appSettings(settings) {
   if (settings.googleAnalytics) {
     result.googleAnalytics = settings.googleAnalytics;
   }
+  if (settings.oauthClientId) {
+    result.oauthClientId = settings.oauthClientId;
+    result.oauthEnabled = settings.oauthEnabled;
+  }
   return result;
 }
 


### PR DESCRIPTION
This adds the OAuth client IDs registered at https://hypothes.is/admin/oauthclients to the browser extension config. OAuth is currently disabled but enabling it once everything else is ready will be a matter of flipping the "oauthEnabled" flag.

Note that this does not yet work for the stage and prod extensions when built locally because the extension IDs are currently different than when using an extension from the Chrome Web Store. You can work around this for testing purposes by copying the "key" entry from `~/Library/Application Support/Google/Chrome/Default/Extensions/{extension ID}/{version}/manifest.json` into `src/chrome/manifest.json.mustache`. This will cause the locally built extension to have the same ID as the extension downloaded from the Chrome web store.

I think we'll probably need to add these "key" entries to the settings files so that locally build stage & prod extensions work as expected. That will prevent having an official prod/stage extension and a locally built one from being installed at the same time, I think. I'm currently investigating this.

----

**Testing:**

1. Build an extension using eg. `make SETTINGS_FILE=settings/chrome-prod.json`
2. Inspect `build/client/app.html` and check that the `oauthClientId` and `oauthEnabled` keys are present.