### PR TITLE
Stop adding h domain to cookie whitelist during install

### DIFF
--- a/src/chrome/manifest.json.mustache
+++ b/src/chrome/manifest.json.mustache
@@ -44,7 +44,6 @@
   "permissions": [
     "<all_urls>",
 
-    "contentSettings",
     "storage",
     "tabs"
   ],

--- a/src/common/install.js
+++ b/src/common/install.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var HypothesisChromeExtension = require('./hypothesis-chrome-extension');
-var settings = require('./settings');
 
 var browserExtension = new HypothesisChromeExtension({
   chromeExtension: chrome.extension,
@@ -54,17 +53,6 @@ function onInstalled(installDetails) {
   if (installDetails.reason === 'install') {
     chrome.management.getSelf(browserExtension.firstRun);
   }
-
-  // We need this so that 3rd party cookie blocking does not kill us.
-  // See https://github.com/hypothesis/h/issues/634 for more info.
-  // This is intended to be a temporary fix only.
-  var details = {
-    primaryPattern: settings.serviceUrl + '*',
-    setting: 'allow',
-  };
-  chrome.contentSettings.cookies.set(details);
-  chrome.contentSettings.images.set(details);
-  chrome.contentSettings.javascript.set(details);
 
   browserExtension.install();
 }

--- a/tests/common/install-test.js
+++ b/tests/common/install-test.js
@@ -32,11 +32,6 @@ describe('install', function () {
         getURL: sinon.stub(),
         isAllowedFileSchemeAccess: sinon.stub(),
       },
-      contentSettings: {
-        cookies: { set: sinon.stub() },
-        images: { set: sinon.stub() },
-        javascript: { set: sinon.stub() },
-      },
       runtime: {
         requestUpdateCheck: sinon.stub(),
         onInstalled: eventListenerStub(),
@@ -74,14 +69,6 @@ describe('install', function () {
     it("calls the extension's first run hook", function () {
       triggerInstallEvent();
       assert.calledWith(extension.firstRun, {id: '1234', installType: 'normal'});
-    });
-
-    it('enables extension to set cookies for service domain', function () {
-      triggerInstallEvent();
-      assert.calledWith(fakeChrome.contentSettings.cookies.set, {
-        primaryPattern: 'https://hypothes.is/*',
-        setting: 'allow',
-      });
     });
   });
 });


### PR DESCRIPTION
As of v1.39, the Hypothesis client detects when third party cookies are
blocked and will use OAuth rather than cookie authentication in that
case. Therefore, we can stop asking for the "contentSettings" permission which produces a scary warning (see hypothesis/browser-extension#46) and remove the code that modifies these browser settings.

There is a potential issue in that the detection of cookie blocking checks reading/writing cookies against the browser extension's domain (`chrome-extension://{id}`) whereas the actual cookies are set for the hypothes.is domain. However, the "block third party cookies" setting in Safari, Firefox and Chrome treats both as third party cookies and so the "can I set cookies" check that the client works as expected.

Fixes hypothesis/browser-extension#46
Fixes hypothesis/product-backlog#359

----

Testing:

1. Remove *all* Hypothesis extensions from Chrome
1. Build this branch using `make SETTINGS_FILE=settings/chrome-prod.json`  and add it to Chrome as an unpacked extension
1. Go to chrome://settings/content/cookies, enable third party cookie blocking and verify that no Hypothesis domains appear in the "Allow" list.
1. Go to https://example.org , activate the extension and click "Log in". This should trigger a pop-up window instead of showing the inline login form. The pop-up may flash and disappear immediately.

Note that after signing in in the pop-up window, nothing happens in the client because a locally-built client currently has a different ID than the one installed from the Chrome web store, so the browser will block the cross-window message that contains the auth code from reaching the client. I'm going to fix this separately.