### PR TITLE
Enable OAuth in the browser extensions

### DIFF
--- a/settings/chrome-prod.json
+++ b/settings/chrome-prod.json
@@ -8,7 +8,7 @@
   "websocketUrl": "wss://hypothes.is/ws",
 
   "oauthClientId": "fd23fe2e-7792-11e7-8e16-23e47a1799d4",
-  "oauthEnabled": false,
+  "oauthEnabled": true,
 
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
   "googleAnalytics": "UA-26026798-5",

--- a/settings/chrome-stage.json
+++ b/settings/chrome-stage.json
@@ -8,7 +8,7 @@
   "websocketUrl": "wss://qa.hypothes.is/ws",
 
   "oauthClientId": "da545114-7792-11e7-90b4-b35c52774c7d",
-  "oauthEnabled": false,
+  "oauthEnabled": true,
 
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
   "googleAnalytics": "UA-26026798-6",

--- a/settings/firefox-prod.json
+++ b/settings/firefox-prod.json
@@ -8,7 +8,7 @@
   "websocketUrl": "wss://hypothes.is/ws",
 
   "oauthClientId": "7fb28342-7793-11e7-90b5-7fed4053f592",
-  "oauthEnabled": false,
+  "oauthEnabled": true,
 
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
   "googleAnalytics": "UA-26026798-5",

--- a/settings/firefox-stage.json
+++ b/settings/firefox-stage.json
@@ -8,7 +8,7 @@
   "websocketUrl": "wss://qa.hypothes.is/ws",
 
   "oauthClientId": "92b42e3c-7793-11e7-8e17-cb2151436a1f",
-  "oauthEnabled": false,
+  "oauthEnabled": true,
 
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
   "googleAnalytics": "UA-26026798-6",


### PR DESCRIPTION
Previously OAuth was only used in the browser extensions if third-party cookies were blocked. This PR enables it as the authentication method for all users.