### PR TITLE
Use fixed IDs for locally built stage and prod extensions

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -41,9 +41,13 @@ Once you've built the extension, you will be able to load the `build/` directory
 as an unpacked extension:
 
 1.  Go to `chrome://extensions/` in Chrome.
-2.  Tick **Developer mode**.
-3.  Click **Load unpacked extension**.
-4.  Browse to the `build/` directory where the extension was built and select it.
+2. If you used the `chrome-prod.json` settings file to build a production
+   extension, you will need to **remove** the "real" production extension from
+   Chrome before loading your locally built one or create a new Chrome profile
+   without the real one installed.
+3.  Tick **Developer mode**.
+4.  Click **Load unpacked extension**.
+5.  Browse to the `build/` directory where the extension was built and select it.
 
 Your extension should be working now! Remember that if you built a development
 extension it will point to a Hypothesis service running on

--- a/settings/chrome-prod.json
+++ b/settings/chrome-prod.json
@@ -1,5 +1,7 @@
 {
   "buildType": "production",
+  "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCq7XsXE/uakq4aKMG5Smz2nc8VSaandriziGorxX08py3mTkab79GpWYu7j/hA3Yf7fkCLQnX8QoZGj7WdaMX6+b+eHxF7vYpOhEW/Bam7TOlb+5AVmL1KReG9PPTLz4dp+xA4WfK2dqFM+XN40FTbm2G/SNk3GRP3gQOxgy3ZKwIDAQAB",
+
 
   "apiUrl": "https://hypothes.is/api/",
   "authDomain": "hypothes.is",

--- a/settings/chrome-stage.json
+++ b/settings/chrome-stage.json
@@ -1,5 +1,6 @@
 {
   "buildType": "staging",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqjbEOhG+ZCl2Bl17m2ltNC+3uw0Fqv3Dzuja5vLnH1MLBRQG7L77pXtKCZgVgFJ2K+Kn0L0OqnMDcKEi5pUpNTi39b8twp1imDsoLO+L5XgpKYBtUgfR+T8OO2INjEgz0LDth0l26WmHNS377KZjSTsfPWNnLozXHHkETgug1lt9VzgcvSboiyZuwk23xHmiqnVpZtuqVAv4HdqFofHiNQn2fF7awsQxEYYNfuSk0Jp33XJkkadyrJ/dQ7vVFi0F0O//Oyaw3s4TD58frABxznusmKkjHZorJUrm2OaYbn/7TSUcG5fReQC08fXiMsFGUKxK01HfAwdmVUAmASL+NwIDAQAB",
 
   "apiUrl": "https://qa.hypothes.is/api/",
   "authDomain": "hypothes.is",

--- a/src/chrome/manifest.json.mustache
+++ b/src/chrome/manifest.json.mustache
@@ -9,6 +9,10 @@
   "minimum_chrome_version": "38",
   {{/browserIsChrome}}
 
+  {{#key}}
+  "key": "{{{ key }}}",
+  {{/key}}
+
   {{#browserIsFirefox}}
   "applications": {
     "gecko": {


### PR DESCRIPTION
_Context: I'm currently updating the client's [development docs](http://h-client.readthedocs.io/en/latest/developers/developing/#setting-up-a-client-development-environment) and addressing the fact that the [running from a browser extension](http://h-client.readthedocs.io/en/latest/developers/developing/#running-the-client-from-the-browser-extension) steps don't "just work" after the OAuth changes_.

----

By default, locally built Chrome extensions get system-dependent IDs which differ from the IDs that are assigned when the extension is published in the Chrome Web Store. The IDs are part of the URLs of the extension's assets (`chrome-extension://{ID}/{path}`), including the url of the sidebar app (`/client/app.html`) which makes the request to the h service's authorization endpoint.

This means that a separate OAuth client would need to be registered in the h service for each user who wanted to build the prod/stage extensions locally. This is a) inconvenient and b) not possible for non-Hypothesis staff.

This PR populates the [key field](https://developer.chrome.com/apps/manifest/key) of the extension manifest at build time so that locally built prod & stage extensions have the same IDs ("bjfhmglciegochdpefhhlphglcehbmek" and "lhieaifenniokmcmfdcgabhbnjmelchg" respectively) as those from the Chrome Web Store, allowing the existing OAuth clients registered in the production "h" service to work.

A downside of this change is that it is not possible to have a locally built prod or stage extension installed at the same time as the "real" versions from the Chrome Web Store, because the IDs would conflict. We could fix this by enabling users to [register OAuth clients themselves](https://github.com/hypothesis/product-backlog/issues/376) in future.

----

**Testing:**

1. Uninstall prod/stage extensions from Chrome Web Store
2. Build prod extension from this PR
3. Check that the ID shown in chrome://extensions is "bjfhmglciegochdpefhhlphglcehbmek"
4. Build stage/QA extension from this PR
5. Check that the ID shown in chrome://extensions is "lhieaifenniokmcmfdcgabhbnjmelchg"

