### PR TITLE
Disable badge by default

### DIFF
--- a/src/chrome/lib/options.js
+++ b/src/chrome/lib/options.js
@@ -3,14 +3,16 @@
 function saveOptions() {
   chrome.storage.sync.set({
     badge: document.getElementById('badge').checked,
+    badgeEnable: document.getElementById('badge').checked,
   });
 }
 
 function loadOptions() {
   chrome.storage.sync.get({
     badge: true,
+    badgeEnable: false,
   }, function(items) {
-    document.getElementById('badge').checked = items.badge;
+    document.getElementById('badge').checked = items.badgeEnable;
   });
 }
 

--- a/src/common/hypothesis-chrome-extension.js
+++ b/src/common/hypothesis-chrome-extension.js
@@ -285,14 +285,17 @@ function HypothesisChromeExtension(dependencies) {
   function updateAnnotationCountIfEnabled(tabId, url) {
     if (!chromeStorage.sync) {
       // Firefox < 53 does not support `chrome.storage.sync`.
-      state.updateAnnotationCount(tabId, url);
+      // If there are no setting options for dissabling the query
+      // for the number of annotations on a page just don't run it.
+      // state.updateAnnotationCount(tabId, url);
       return;
     }
 
     chromeStorage.sync.get({
       badge: true,
+      badgeEnable: false,
     }, function (items) {
-      if (items.badge) {
+      if (items.badgeEnable) {
         state.updateAnnotationCount(tabId, url);
       }
     });

--- a/tests/common/hypothesis-chrome-extension-test.js
+++ b/tests/common/hypothesis-chrome-extension-test.js
@@ -61,7 +61,7 @@ describe('HypothesisChromeExtension', function () {
   beforeEach(function () {
     fakeChromeStorage = {
       sync: {
-        get: sandbox.stub().callsArgWith(1, {badge: true}),
+        get: sandbox.stub().callsArgWith(1, {badge: true, badgeEnable: false}),
       },
     };
     fakeChromeTabs = {
@@ -299,24 +299,25 @@ describe('HypothesisChromeExtension', function () {
 
       it('updates the badge count', function () {
         var tab = createTab();
+        fakeChromeStorage.sync.get.callsArgWith(1, {badgeEnable: true});
+
         fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
         fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
         assert.calledWith(fakeTabState.updateAnnotationCount, tab.id, 'http://example.com/foo.html');
       });
 
-      it('updates the badge count if "chrome.storage.sync" is not supported', function () {
+      it('does not update the badge count if "chrome.storage.sync" is not supported', function () {
         var tab = createTab();
         delete fakeChromeStorage.sync;
 
         fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
         fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
 
-        assert.calledWith(fakeTabState.updateAnnotationCount, tab.id, 'http://example.com/foo.html');
+        assert.notCalled(fakeTabState.updateAnnotationCount);
       });
 
       it('does not update the badge count if the option is disabled', function () {
         var tab = createTab();
-        fakeChromeStorage.sync.get.callsArgWith(1, {badge: false});
 
         fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
         fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);


### PR DESCRIPTION
Disable the badge by default and on firefox disable it permanently
(as there is no setting to enable it). In order to do this we need
to add a new badgeEnable state param to the store, otherwise any
previously installed extension settings will override the default
settings of the latest version and the badge won't be disabled.
The badge is being changed to an opt in setting because it accounts
for 90% of our transactions and is a scallabilty problem. Every
page the user browses to when the badge is enabled causes a
transaction to es and our db.