### PR TITLE
Update Node version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: '6.2'
+node_js: 'lts/*'
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
The current version of `web-ext` depends on Node >= v6.3 or later due to
use of `fs.constants`.

This commit configures Travis to use the current LTS release of Node (v8.x),
which should hopefully always be current enough without running into
occassional issues with dependencies that sometimes happen when a new
stable Node release (currently v9.x) comes out.

This should fix this deployment failure: https://travis-ci.org/hypothesis/browser-extension/builds/369061182