### PR TITLE
Use `npm ci` to install dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: node_js
 node_js: 'lts/*'
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+install:
+  - npm install -g npm
+  - npm ci
 script:
   - npm test
   - make SETTINGS_FILE=settings/chrome-prod.json dist/$(date +'%Y%m%d')-chrome-prod.zip


### PR DESCRIPTION
By default Travis runs `npm install`. This can end up modifying
`package-lock.json` if Travis has a different version of npm than
whoever committed the last changes to the lockfile.

`npm ci` should avoid this problem by installing _only_ from the
lockfile. This command also promises faster installation. Since this
command was introduced in npm v5.7, we need to first install a newer
version of npm.

 - Change the cache directory as per the `npm ci` docs.