### PR TITLE
Revert "Make return value of boot script serializable"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,6 @@ build/client/build: node_modules/hypothesis/build/manifest.json
 	@# We can't leave the client manifest in the build or the Chrome Web Store
 	@# will complain.
 	rm $@/manifest.json
-	@# Add a serializable expression as the last statement in the boot script
-	@# bundle, otherwise Firefox will complain if attempting to execute the Browserify
-	@# bundle that the "Script returned non-structured-clonable data"
-	echo "null" >> build/client/build/boot.js
-
 build/client/app.html: src/client/app.html.mustache build/client build/.settings.json
 	tools/template-context-app.js build/.settings.json | $(MUSTACHE) - $< >$@
 build/settings-data.js: src/chrome/settings-data.js.mustache build/client build/.settings.json


### PR DESCRIPTION
Appending this token to the end of `boot.js` causes a syntax error with the
latest version of the client since the structure of the code changed.

Additionally the hack does not appear to be required any more (tested with Firefox 64).

This reverts commit 2674d22cbfda70627ba225f99af815a457f1ab19.