### PR TITLE
Add prettier to project and reformat code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
   "extends": "hypothesis",
   "globals": {
     "chrome": false
+  },
+  "rules": {
+    "indent": "off"
   }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore PDF.js
+src/chrome/content/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ install:
   - npm install -g npm
   - npm ci
 script:
+  - make checkformatting
+  - make lint
   - npm test
   - make SETTINGS_FILE=settings/chrome-prod.json dist/$(date +'%Y%m%d')-chrome-prod.zip
   - make SETTINGS_FILE=settings/chrome-stage.json dist/$(date +'%Y%m%d')-chrome-stage.zip

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ BROWSERIFY := node_modules/.bin/browserify
 ESLINT := node_modules/.bin/eslint
 EXORCIST := node_modules/.bin/exorcist
 MUSTACHE := node_modules/.bin/mustache
+PRETTIER := node_modules/.bin/prettier
 
 .PHONY: default
 default: extension
@@ -66,5 +67,13 @@ dist/%.zip dist/%.xpi: extension
 .PHONY: lint
 lint:
 	$(ESLINT) .
+
+.PHONY: checkformatting
+checkformatting:
+	$(PRETTIER) --check 'src/**/*.js' 'tests/**/*.js'
+
+.PHONY: format
+format:
+	$(PRETTIER) --list-different --write 'src/**/*.js' 'tests/**/*.js'
 
 -include build/.*.deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -9937,6 +9937,12 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "dev": true
+    },
     "private": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "karma-sinon": "^1.0.5",
     "mocha": "^5.2.0",
     "mustache": "^2.2.1",
+    "prettier": "1.16.4",
     "proxyquire": "^1.7.4",
     "proxyquire-universal": "^1.0.8",
     "proxyquireify": "^3.1.1",

--- a/src/chrome/help/index.js
+++ b/src/chrome/help/index.js
@@ -5,8 +5,8 @@ function parseQuery(query) {
   if (query.charAt(0) === '?') {
     query = query.slice(1);
   }
-  return query.split('&').reduce(function (map, entry) {
-    var keyValue = entry.split('=').map(function (e) {
+  return query.split('&').reduce(function(map, entry) {
+    var keyValue = entry.split('=').map(function(e) {
       return decodeURIComponent(e);
     });
     map[keyValue[0]] = keyValue[1];
@@ -15,9 +15,9 @@ function parseQuery(query) {
 }
 
 // Detect the current OS and show approprite help.
-chrome.runtime.getPlatformInfo(function (info) {
+chrome.runtime.getPlatformInfo(function(info) {
   var opts = document.querySelectorAll('[data-extension-path]');
-  [].forEach.call(opts, function (opt) {
+  [].forEach.call(opts, function(opt) {
     if (opt.dataset.extensionPath !== info.os) {
       opt.hidden = true;
     }

--- a/src/chrome/lib/destroy.js
+++ b/src/chrome/lib/destroy.js
@@ -3,8 +3,9 @@
 
 'use strict';
 
-var annotatorLink =
-  document.querySelector('link[type="application/annotator+html"]');
+var annotatorLink = document.querySelector(
+  'link[type="application/annotator+html"]'
+);
 
 if (annotatorLink) {
   // Dispatch a 'destroy' event which is handled by the code in

--- a/src/chrome/lib/options.js
+++ b/src/chrome/lib/options.js
@@ -7,11 +7,14 @@ function saveOptions() {
 }
 
 function loadOptions() {
-  chrome.storage.sync.get({
-    badge: true,
-  }, function(items) {
-    document.getElementById('badge').checked = items.badge;
-  });
+  chrome.storage.sync.get(
+    {
+      badge: true,
+    },
+    function(items) {
+      document.getElementById('badge').checked = items.badge;
+    }
+  );
 }
 
 document.addEventListener('DOMContentLoaded', loadOptions);

--- a/src/common/browser-action.js
+++ b/src/common/browser-action.js
@@ -80,7 +80,7 @@ function BrowserAction(chromeBrowserAction) {
         countLabel = _("There's 1 annotation on this page");
       } else {
         countLabel = _(
-          'There are ' + totalString + ' annotations on ' + 'this page'
+          'There are ' + totalString + ' annotations on this page'
         );
       }
       title = countLabel;

--- a/src/common/browser-action.js
+++ b/src/common/browser-action.js
@@ -23,11 +23,11 @@ var buildType = settings.buildType;
 // themes to apply to the toolbar icon badge depending on the type of
 // build. Production builds use the default color and no text
 var badgeThemes = {
-  'dev': {
+  dev: {
     defaultText: 'DEV',
     color: '#5BCF59', // Emerald green
   },
-  'staging': {
+  staging: {
     defaultText: 'STG',
     color: '#EDA061', // Porche orange-pink
   },
@@ -79,8 +79,9 @@ function BrowserAction(chromeBrowserAction) {
       if (state.annotationCount === 1) {
         countLabel = _("There's 1 annotation on this page");
       } else {
-        countLabel = _('There are ' + totalString + ' annotations on ' +
-                  'this page');
+        countLabel = _(
+          'There are ' + totalString + ' annotations on ' + 'this page'
+        );
       }
       title = countLabel;
       badgeText = totalString;
@@ -98,9 +99,9 @@ function BrowserAction(chromeBrowserAction) {
       }
     }
 
-    chromeBrowserAction.setBadgeText({tabId: tabId, text: badgeText});
-    chromeBrowserAction.setIcon({tabId: tabId, path: activeIcon});
-    chromeBrowserAction.setTitle({tabId: tabId, title: title});
+    chromeBrowserAction.setBadgeText({ tabId: tabId, text: badgeText });
+    chromeBrowserAction.setIcon({ tabId: tabId, path: activeIcon });
+    chromeBrowserAction.setTitle({ tabId: tabId, title: title });
   };
 }
 

--- a/src/common/detect-content-type.js
+++ b/src/common/detect-content-type.js
@@ -25,8 +25,10 @@ function detectContentType(document_) {
     // see this document, open the inspector on a PDF viewer tab with
     // Ctrl+Shift+I rather than right-clicking on the viewport and selecting the
     // 'Inspect' option which will instead show the _inner_ document.
-    if (document_.querySelector('embed[type="application/pdf"][name="plugin"]')) {
-      return {type: 'PDF'};
+    if (
+      document_.querySelector('embed[type="application/pdf"][name="plugin"]')
+    ) {
+      return { type: 'PDF' };
     }
     return null;
   }
@@ -42,7 +44,7 @@ function detectContentType(document_) {
     // `window.PDFViewerApplication` object. This however requires running JS
     // code in the same JS context as the page's own code.
     if (document_.baseURI.indexOf('resource://pdf.js') === 0) {
-      return {type: 'PDF'};
+      return { type: 'PDF' };
     }
     return null;
   }
@@ -55,7 +57,7 @@ function detectContentType(document_) {
     }
   }
 
-  return {type: 'HTML'};
+  return { type: 'HTML' };
 }
 
 module.exports = detectContentType;

--- a/src/common/errors.js
+++ b/src/common/errors.js
@@ -61,9 +61,11 @@ var IGNORED_ERRORS = [
  * @param {{message: string}} err - The Error-like object
  */
 function shouldIgnoreInjectionError(err) {
-  if (IGNORED_ERRORS.some(function (pattern) {
-    return err.message.match(pattern);
-  })) {
+  if (
+    IGNORED_ERRORS.some(function(pattern) {
+      return err.message.match(pattern);
+    })
+  ) {
     return true;
   }
   if (isKnownError(err)) {

--- a/src/common/help-page.js
+++ b/src/common/help-page.js
@@ -21,27 +21,26 @@ function HelpPage(chromeTabs, extensionURL, browserName_) {
    * @param {Error} error - The error to display, usually an instance of
    *                        errors.ExtensionError
    */
-  this.showHelpForError = function (tab, error) {
+  this.showHelpForError = function(tab, error) {
     if (error instanceof errors.LocalFileError) {
       return this.showLocalFileHelpPage(tab);
-    }
-    else if (error instanceof errors.NoFileAccessError) {
+    } else if (error instanceof errors.NoFileAccessError) {
       return this.showNoFileAccessHelpPage(tab);
-    }
-    else if (error instanceof errors.RestrictedProtocolError) {
+    } else if (error instanceof errors.RestrictedProtocolError) {
       return this.showRestrictedProtocolPage(tab);
-    }
-    else if (error instanceof errors.BlockedSiteError) {
+    } else if (error instanceof errors.BlockedSiteError) {
       return this.showBlockedSitePage(tab);
-    }
-    else {
+    } else {
       return this.showOtherErrorPage(tab, error);
     }
   };
 
   this.showLocalFileHelpPage = showHelpPage.bind(null, 'local-file');
   this.showNoFileAccessHelpPage = showHelpPage.bind(null, 'no-file-access');
-  this.showRestrictedProtocolPage = showHelpPage.bind(null, 'restricted-protocol');
+  this.showRestrictedProtocolPage = showHelpPage.bind(
+    null,
+    'restricted-protocol'
+  );
   this.showBlockedSitePage = showHelpPage.bind(null, 'blocked-site');
   this.showOtherErrorPage = showHelpPage.bind(null, 'other-error');
 
@@ -60,7 +59,7 @@ function HelpPage(chromeTabs, extensionURL, browserName_) {
 
     var tabOpts = {
       index: tab.index + 1,
-      url:  extensionURL('/help/index.html' + params + '#' + helpSection),
+      url: extensionURL('/help/index.html' + params + '#' + helpSection),
     };
 
     // Add `openerTabId` property to associate the help page tab with the

--- a/src/common/hypothesis-chrome-extension.js
+++ b/src/common/hypothesis-chrome-extension.js
@@ -44,7 +44,7 @@ function HypothesisChromeExtension(dependencies) {
   var chromeExtension = dependencies.chromeExtension;
   var chromeStorage = dependencies.chromeStorage;
   var chromeBrowserAction = dependencies.chromeBrowserAction;
-  var help  = new HelpPage(chromeTabs, dependencies.extensionURL);
+  var help = new HelpPage(chromeTabs, dependencies.extensionURL);
   var store = new TabStore(localStorage);
   var state = new TabState(store.all(), onTabStateChange);
   var browserAction = new BrowserAction(chromeBrowserAction);
@@ -58,7 +58,7 @@ function HypothesisChromeExtension(dependencies) {
   /* Sets up the extension and binds event listeners. Requires a window
    * object to be passed so that it can listen for localStorage events.
    */
-  this.listen = function () {
+  this.listen = function() {
     chromeBrowserAction.onClicked.addListener(onBrowserActionClicked);
     chromeTabs.onCreated.addListener(onTabCreated);
 
@@ -78,12 +78,12 @@ function HypothesisChromeExtension(dependencies) {
   /* A method that can be used to setup the extension on existing tabs
    * when the extension is re-installed.
    */
-  this.install = function () {
+  this.install = function() {
     restoreSavedTabState();
   };
 
   /* Opens the onboarding page */
-  this.firstRun = function (extensionInfo) {
+  this.firstRun = function(extensionInfo) {
     // If we've been installed because of an administrative policy, then don't
     // open the welcome page in a new tab.
     //
@@ -99,7 +99,7 @@ function HypothesisChromeExtension(dependencies) {
       return;
     }
 
-    chromeTabs.create({url: settings.serviceUrl + 'welcome'}, function (tab) {
+    chromeTabs.create({ url: settings.serviceUrl + 'welcome' }, function(tab) {
       state.activateTab(tab.id);
     });
   };
@@ -107,8 +107,8 @@ function HypothesisChromeExtension(dependencies) {
   function restoreSavedTabState() {
     store.reload();
     state.load(store.all());
-    chromeTabs.query({}, function (tabs) {
-      tabs.forEach(function (tab) {
+    chromeTabs.query({}, function(tabs) {
+      tabs.forEach(function(tab) {
         onTabStateChange(tab.id, state.getState(tab.id));
       });
     });
@@ -134,11 +134,9 @@ function HypothesisChromeExtension(dependencies) {
     var tabError = state.getState(tab.id).error;
     if (tabError) {
       help.showHelpForError(tab, tabError);
-    }
-    else if (state.isTabActive(tab.id)) {
+    } else if (state.isTabActive(tab.id)) {
       state.deactivateTab(tab.id);
-    }
-    else {
+    } else {
       state.activateTab(tab.id);
     }
   }
@@ -201,7 +199,7 @@ function HypothesisChromeExtension(dependencies) {
     });
     state.clearTab(removedTabId);
 
-    chromeTabs.get(addedTabId, function (tab) {
+    chromeTabs.get(addedTabId, function(tab) {
       updateAnnotationCountIfEnabled(addedTabId, tab.url);
     });
   }
@@ -251,12 +249,13 @@ function HypothesisChromeExtension(dependencies) {
         }
       }
 
-      return sidebar.injectIntoTab(tab, config)
-        .then(function () {
+      return sidebar
+        .injectIntoTab(tab, config)
+        .then(function() {
           // Clear the direct link once H has been successfully injected
           state.setState(tab.id, { directLinkQuery: undefined });
         })
-        .catch(function (err) {
+        .catch(function(err) {
           if (err instanceof errors.AlreadyInjectedError) {
             state.setState(tab.id, {
               state: TabState.states.INACTIVE,
@@ -272,7 +271,7 @@ function HypothesisChromeExtension(dependencies) {
           state.errorTab(tab.id, err);
         });
     } else if (state.isTabInactive(tab.id) && isInstalled) {
-      return sidebar.removeFromTab(tab).then(function () {
+      return sidebar.removeFromTab(tab).then(function() {
         state.setState(tab.id, {
           extensionSidebarInstalled: false,
         });
@@ -289,13 +288,16 @@ function HypothesisChromeExtension(dependencies) {
       return;
     }
 
-    chromeStorage.sync.get({
-      badge: true,
-    }, function (items) {
-      if (items.badge) {
-        state.updateAnnotationCount(tabId, url);
+    chromeStorage.sync.get(
+      {
+        badge: true,
+      },
+      function(items) {
+        if (items.badge) {
+          state.updateAnnotationCount(tabId, url);
+        }
       }
-    });
+    );
   }
 }
 

--- a/src/common/install.js
+++ b/src/common/install.js
@@ -7,10 +7,10 @@ var browserExtension = new HypothesisChromeExtension({
   chromeTabs: chrome.tabs,
   chromeBrowserAction: chrome.browserAction,
   chromeStorage: chrome.storage,
-  extensionURL: function (path) {
+  extensionURL: function(path) {
     return chrome.extension.getURL(path);
   },
-  isAllowedFileSchemeAccess: function (fn) {
+  isAllowedFileSchemeAccess: function(fn) {
     return chrome.extension.isAllowedFileSchemeAccess(fn);
   },
 });
@@ -24,17 +24,19 @@ if (chrome.runtime.onInstalled) {
 // Respond to messages sent by the JavaScript from https://hyp.is.
 // This is how it knows whether the user has this Chrome extension installed.
 if (chrome.runtime.onMessageExternal) {
-  chrome.runtime.onMessageExternal.addListener(
-    function (request, sender, sendResponse) {
-      if (request.type === 'ping') {
-        sendResponse({type: 'pong'});
-      }
+  chrome.runtime.onMessageExternal.addListener(function(
+    request,
+    sender,
+    sendResponse
+  ) {
+    if (request.type === 'ping') {
+      sendResponse({ type: 'pong' });
     }
-  );
+  });
 }
 
 if (chrome.runtime.requestUpdateCheck) {
-  chrome.runtime.requestUpdateCheck(function () {
+  chrome.runtime.requestUpdateCheck(function() {
     chrome.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
   });
 }

--- a/src/common/raven.js
+++ b/src/common/raven.js
@@ -28,7 +28,10 @@ function convertLocalURLsToFilenames(url) {
 
   // Strip the query string (which is used as a cache buster)
   // and extract the filename from the URL
-  return url.replace(/\?.*/,'').split('/').slice(-1)[0];
+  return url
+    .replace(/\?.*/, '')
+    .split('/')
+    .slice(-1)[0];
 }
 
 /**
@@ -50,7 +53,7 @@ function convertLocalURLsToFilenames(url) {
 function translateSourceURLs(data) {
   try {
     var frames = data.exception.values[0].stacktrace.frames;
-    frames.forEach(function (frame) {
+    frames.forEach(function(frame) {
       frame.filename = convertLocalURLsToFilenames(frame.filename);
     });
     data.culprit = frames[0].filename;
@@ -111,7 +114,7 @@ function report(error, when, context) {
  * automatically, in which case this code can simply be removed.
  */
 function installUnhandledPromiseErrorHandler() {
-  window.addEventListener('unhandledrejection', function (event) {
+  window.addEventListener('unhandledrejection', function(event) {
     if (event.reason) {
       report(event.reason, 'Unhandled Promise rejection');
     }

--- a/src/common/tab-state.js
+++ b/src/common/tab-state.js
@@ -5,9 +5,9 @@ var isShallowEqual = require('is-equal-shallow');
 var uriInfo = require('./uri-info');
 
 var states = {
-  ACTIVE:   'active',
+  ACTIVE: 'active',
   INACTIVE: 'inactive',
-  ERRORED:  'errored',
+  ERRORED: 'errored',
 };
 
 /** The default H state for a new browser tab */
@@ -59,34 +59,38 @@ function TabState(initialState, onchange) {
    *                   The provided state will be merged with the default
    *                   state for a tab.
    */
-  this.load = function (newState) {
+  this.load = function(newState) {
     var newCurrentState = {};
-    Object.keys(newState).forEach(function (tabId) {
-      newCurrentState[tabId] = Object.assign({}, DEFAULT_STATE, newState[tabId]);
+    Object.keys(newState).forEach(function(tabId) {
+      newCurrentState[tabId] = Object.assign(
+        {},
+        DEFAULT_STATE,
+        newState[tabId]
+      );
     });
     currentState = newCurrentState;
   };
 
-  this.activateTab = function (tabId) {
-    this.setState(tabId, {state: states.ACTIVE});
+  this.activateTab = function(tabId) {
+    this.setState(tabId, { state: states.ACTIVE });
   };
 
-  this.deactivateTab = function (tabId) {
-    this.setState(tabId, {state: states.INACTIVE});
+  this.deactivateTab = function(tabId) {
+    this.setState(tabId, { state: states.INACTIVE });
   };
 
-  this.errorTab = function (tabId, error) {
+  this.errorTab = function(tabId, error) {
     this.setState(tabId, {
       state: states.ERRORED,
       error: error,
     });
   };
 
-  this.clearTab = function (tabId) {
+  this.clearTab = function(tabId) {
     this.setState(tabId, null);
   };
 
-  this.getState = function (tabId) {
+  this.getState = function(tabId) {
     if (!currentState[tabId]) {
       return DEFAULT_STATE;
     }
@@ -97,15 +101,15 @@ function TabState(initialState, onchange) {
     return this.getState(tabId).annotationCount;
   };
 
-  this.isTabActive = function (tabId) {
+  this.isTabActive = function(tabId) {
     return this.getState(tabId).state === states.ACTIVE;
   };
 
-  this.isTabInactive = function (tabId) {
+  this.isTabInactive = function(tabId) {
     return this.getState(tabId).state === states.INACTIVE;
   };
 
-  this.isTabErrored = function (tabId) {
+  this.isTabErrored = function(tabId) {
     return this.getState(tabId).state === states.ERRORED;
   };
 
@@ -117,7 +121,7 @@ function TabState(initialState, onchange) {
    *                      state properties to update or null if the
    *                      state should be removed.
    */
-  this.setState = function (tabId, stateUpdate) {
+  this.setState = function(tabId, stateUpdate) {
     var newState;
     if (stateUpdate) {
       newState = Object.assign({}, this.getState(tabId), stateUpdate);
@@ -147,12 +151,19 @@ function TabState(initialState, onchange) {
    */
   this.updateAnnotationCount = function(tabId, tabUrl) {
     var self = this;
-    return uriInfo.query(tabUrl).then(function (result) {
-      self.setState(tabId, { annotationCount: result.total });
-    }).catch(function (err) {
-      self.setState(tabId, { annotationCount: 0 });
-      console.error('Failed to fetch annotation count for %s: %s', tabUrl, err);
-    });
+    return uriInfo
+      .query(tabUrl)
+      .then(function(result) {
+        self.setState(tabId, { annotationCount: result.total });
+      })
+      .catch(function(err) {
+        self.setState(tabId, { annotationCount: 0 });
+        console.error(
+          'Failed to fetch annotation count for %s: %s',
+          tabUrl,
+          err
+        );
+      });
   };
 
   this.load(initialState || {});

--- a/src/common/tab-store.js
+++ b/src/common/tab-store.js
@@ -11,7 +11,7 @@ function TabStore(storage) {
   var key = 'state';
   var local;
 
-  this.get = function (tabId) {
+  this.get = function(tabId) {
     var value = local[tabId];
     if (!value) {
       throw new Error('TabStateStore could not find entry for tab: ' + tabId);
@@ -19,7 +19,7 @@ function TabStore(storage) {
     return value;
   };
 
-  this.set = function (tabId, value) {
+  this.set = function(tabId, value) {
     // copy across only the parts of the tab state that should
     // be preserved
     local[tabId] = {
@@ -29,25 +29,25 @@ function TabStore(storage) {
     storage.setItem(key, JSON.stringify(local));
   };
 
-  this.unset = function (tabId) {
+  this.unset = function(tabId) {
     delete local[tabId];
     storage.setItem(key, JSON.stringify(local));
   };
 
-  this.all = function () {
+  this.all = function() {
     return local;
   };
 
-  this.reload = function () {
+  this.reload = function() {
     try {
       local = {};
       var loaded = JSON.parse(storage.getItem(key));
-      Object.keys(loaded).forEach(function (key) {
+      Object.keys(loaded).forEach(function(key) {
         // ignore tab state saved by earlier versions of
         // the extension which saved the state as a {key: <state string>}
         // dict rather than {key: <state object>}
         if (typeof loaded[key] === 'string') {
-          local[key] = {state: loaded[key]};
+          local[key] = { state: loaded[key] };
         } else {
           local[key] = loaded[key];
         }

--- a/src/common/uri-info.js
+++ b/src/common/uri-info.js
@@ -12,11 +12,13 @@ function encodeUriQuery(val) {
  * statistics about the annotations for a given URL.
  */
 function query(uri) {
-  return fetch(settings.apiUrl + '/badge?uri=' + encodeUriQuery(uri),
-               {credentials: 'include'})
-    .then(function (res) {
+  return fetch(settings.apiUrl + '/badge?uri=' + encodeUriQuery(uri), {
+    credentials: 'include',
+  })
+    .then(function(res) {
       return res.json();
-    }).then(function (data) {
+    })
+    .then(function(data) {
       if (typeof data.total !== 'number') {
         throw new Error('Annotation count is not a number');
       }

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -25,17 +25,20 @@ function getLastError() {
  *           is set or resolved with the first argument to the callback otherwise.
  */
 function promisify(fn) {
-  return function () {
+  return function() {
     var args = [].slice.call(arguments);
-    var result = new Promise(function (resolve, reject) {
-      fn.apply(this, args.concat(function (result) {
-        var lastError = getLastError();
-        if (lastError) {
-          reject(lastError);
-        } else {
-          resolve(result);
-        }
-      }));
+    var result = new Promise(function(resolve, reject) {
+      fn.apply(
+        this,
+        args.concat(function(result) {
+          var lastError = getLastError();
+          if (lastError) {
+            reject(lastError);
+          } else {
+            resolve(result);
+          }
+        })
+      );
     });
     return result;
   };

--- a/tests/bootstrap.js
+++ b/tests/bootstrap.js
@@ -3,4 +3,4 @@
 window.EXTENSION_CONFIG = require('./settings.json');
 
 // Expose the sinon assertions.
-sinon.assert.expose(assert, {prefix: null});
+sinon.assert.expose(assert, { prefix: null });

--- a/tests/common/browser-action-test.js
+++ b/tests/common/browser-action-test.js
@@ -3,78 +3,87 @@
 var assign = require('core-js/modules/$.object-assign');
 var proxyquire = require('proxyquire');
 
-describe('BrowserAction', function () {
+describe('BrowserAction', function() {
   var BrowserAction = require('../../src/common/browser-action');
   var TabState = require('../../src/common/tab-state');
   var action;
   var fakeChromeBrowserAction;
 
-  beforeEach(function () {
+  beforeEach(function() {
     fakeChromeBrowserAction = {
       annotationCount: 0,
       title: '',
       badgeText: '',
       badgeColor: '',
 
-      setIcon: function (options) {
+      setIcon: function(options) {
         this.icon = options.path;
       },
-      setTitle: function (options) {
+      setTitle: function(options) {
         this.title = options.title;
       },
-      setBadgeText: function (options) {
+      setBadgeText: function(options) {
         this.badgeText = options.text;
       },
-      setBadgeBackgroundColor: function (options) {
+      setBadgeBackgroundColor: function(options) {
         this.badgeColor = options.color;
       },
     };
     action = new BrowserAction(fakeChromeBrowserAction);
   });
 
-  describe('active state', function () {
-    it('sets the active browser icon', function () {
-      action.update(1, {state: TabState.states.ACTIVE});
-      assert.equal(fakeChromeBrowserAction.icon, BrowserAction.icons[TabState.states.ACTIVE]);
+  describe('active state', function() {
+    it('sets the active browser icon', function() {
+      action.update(1, { state: TabState.states.ACTIVE });
+      assert.equal(
+        fakeChromeBrowserAction.icon,
+        BrowserAction.icons[TabState.states.ACTIVE]
+      );
     });
 
-    it('sets the title of the browser icon', function () {
-      action.update(1, {state: TabState.states.ACTIVE});
+    it('sets the title of the browser icon', function() {
+      action.update(1, { state: TabState.states.ACTIVE });
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis is active');
     });
 
-    it('does not set the title if there is badge text showing', function () {
+    it('does not set the title if there is badge text showing', function() {
       var state = {
         state: TabState.states.INACTIVE,
         annotationCount: 9,
       };
       action.update(1, state);
       var prevTitle = fakeChromeBrowserAction.title;
-      action.update(1, assign(state, {state: TabState.states.ACTIVE}));
+      action.update(1, assign(state, { state: TabState.states.ACTIVE }));
       assert.equal(fakeChromeBrowserAction.title, prevTitle);
     });
   });
 
-  describe('inactive state', function () {
-    it('sets the inactive browser icon and title', function () {
-      action.update(1, {state: TabState.states.INACTIVE});
-      assert.equal(fakeChromeBrowserAction.icon, BrowserAction.icons[TabState.states.INACTIVE]);
+  describe('inactive state', function() {
+    it('sets the inactive browser icon and title', function() {
+      action.update(1, { state: TabState.states.INACTIVE });
+      assert.equal(
+        fakeChromeBrowserAction.icon,
+        BrowserAction.icons[TabState.states.INACTIVE]
+      );
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis is inactive');
     });
   });
 
-  describe('error state', function () {
-    it('sets the inactive browser icon', function () {
-      action.update(1, {state: TabState.states.ERRORED});
-      assert.equal(fakeChromeBrowserAction.icon, BrowserAction.icons[TabState.states.INACTIVE]);
+  describe('error state', function() {
+    it('sets the inactive browser icon', function() {
+      action.update(1, { state: TabState.states.ERRORED });
+      assert.equal(
+        fakeChromeBrowserAction.icon,
+        BrowserAction.icons[TabState.states.INACTIVE]
+      );
     });
 
-    it('sets the title of the browser icon', function () {
-      action.update(1, {state: TabState.states.ERRORED});
+    it('sets the title of the browser icon', function() {
+      action.update(1, { state: TabState.states.ERRORED });
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis failed to load');
     });
 
-    it('still sets the title even there is badge text showing', function () {
+    it('still sets the title even there is badge text showing', function() {
       action.update(1, {
         state: TabState.states.ERRORED,
         annotationCount: 9,
@@ -82,7 +91,7 @@ describe('BrowserAction', function () {
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis failed to load');
     });
 
-    it('shows a badge', function () {
+    it('shows a badge', function() {
       action.update(1, {
         state: TabState.states.ERRORED,
       });
@@ -90,7 +99,7 @@ describe('BrowserAction', function () {
     });
   });
 
-  describe('annotation counts', function () {
+  describe('annotation counts', function() {
     it('sets the badge text', function() {
       action.update(1, {
         state: TabState.states.INACTIVE,
@@ -99,25 +108,27 @@ describe('BrowserAction', function () {
       assert.equal(fakeChromeBrowserAction.badgeText, '23');
     });
 
-    it("sets the badge title when there's 1 annotation",
-      function () {
-        action.update(1, {
-          state: TabState.states.INACTIVE,
-          annotationCount: 1,
-        });
-        assert.equal(fakeChromeBrowserAction.title,
-        "There's 1 annotation on this page");
+    it("sets the badge title when there's 1 annotation", function() {
+      action.update(1, {
+        state: TabState.states.INACTIVE,
+        annotationCount: 1,
       });
+      assert.equal(
+        fakeChromeBrowserAction.title,
+        "There's 1 annotation on this page"
+      );
+    });
 
-    it("sets the badge title when there's >1 annotation",
-        function() {
-          action.update(1, {
-            state: TabState.states.INACTIVE,
-            annotationCount: 23,
-          });
-          assert.equal(fakeChromeBrowserAction.title,
-        'There are 23 annotations on this page');
-        });
+    it("sets the badge title when there's >1 annotation", function() {
+      action.update(1, {
+        state: TabState.states.INACTIVE,
+        annotationCount: 23,
+      });
+      assert.equal(
+        fakeChromeBrowserAction.title,
+        'There are 23 annotations on this page'
+      );
+    });
 
     it('does not set the badge text if there are 0 annotations', function() {
       action.update(1, {
@@ -141,13 +152,15 @@ describe('BrowserAction', function () {
         annotationCount: 1001,
       });
       assert.equal(fakeChromeBrowserAction.badgeText, '999+');
-      assert.equal(fakeChromeBrowserAction.title,
-        'There are 999+ annotations on this page');
+      assert.equal(
+        fakeChromeBrowserAction.title,
+        'There are 999+ annotations on this page'
+      );
     });
   });
 
-  describe('build type', function () {
-    beforeEach(function () {
+  describe('build type', function() {
+    beforeEach(function() {
       var fakeSettings = {
         buildType: 'staging',
         '@noCallThru': true,
@@ -159,7 +172,7 @@ describe('BrowserAction', function () {
       return fakeSettings;
     });
 
-    it('sets the text to STG when there are no annotations', function () {
+    it('sets the text to STG when there are no annotations', function() {
       action.update(1, {
         state: TabState.states.INACTIVE,
         annotationCount: 0,
@@ -167,7 +180,7 @@ describe('BrowserAction', function () {
       assert.equal(fakeChromeBrowserAction.badgeText, 'STG');
     });
 
-    it('shows the annotation count when there are annotations', function () {
+    it('shows the annotation count when there are annotations', function() {
       action.update(1, {
         state: TabState.states.INACTIVE,
         annotationCount: 3,
@@ -175,7 +188,7 @@ describe('BrowserAction', function () {
       assert.equal(fakeChromeBrowserAction.badgeText, '3');
     });
 
-    it('sets the background color', function () {
+    it('sets the background color', function() {
       action.update(1, {
         state: TabState.states.INACTIVE,
         annotationCount: 0,

--- a/tests/common/detect-content-type-test.js
+++ b/tests/common/detect-content-type-test.js
@@ -2,30 +2,32 @@
 
 var detectContentType = require('../../src/common/detect-content-type');
 
-describe('detectContentType()', function () {
+describe('detectContentType()', function() {
   var el;
-  beforeEach(function () {
+  beforeEach(function() {
     el = document.createElement('div');
     document.body.appendChild(el);
   });
 
-  afterEach(function () {
+  afterEach(function() {
     el.parentElement.removeChild(el);
   });
 
-  it('returns HTML by default', function () {
+  it('returns HTML by default', function() {
     el.innerHTML = '<div></div>';
-    assert.deepEqual(detectContentType(), { type: 'HTML' } );
+    assert.deepEqual(detectContentType(), { type: 'HTML' });
   });
 
-  it('returns "PDF" if Google Chrome PDF viewer is present', function () {
+  it('returns "PDF" if Google Chrome PDF viewer is present', function() {
     el.innerHTML = '<embed name="plugin" type="application/pdf"></embed>';
     assert.deepEqual(detectContentType(), { type: 'PDF' });
   });
 
-  it('returns "PDF" if Firefox PDF viewer is present', function () {
+  it('returns "PDF" if Firefox PDF viewer is present', function() {
     var fakeDocument = {
-      querySelector: function () { return null; },
+      querySelector: function() {
+        return null;
+      },
       baseURI: 'resource://pdf.js',
     };
     assert.deepEqual(detectContentType(fakeDocument), { type: 'PDF' });

--- a/tests/common/errors-test.js
+++ b/tests/common/errors-test.js
@@ -2,11 +2,11 @@
 
 var proxyquire = require('proxyquire');
 
-describe('errors', function () {
+describe('errors', function() {
   var fakeRaven;
   var errors;
 
-  beforeEach(function () {
+  beforeEach(function() {
     fakeRaven = {
       report: sinon.stub(),
     };
@@ -17,52 +17,50 @@ describe('errors', function () {
     sinon.stub(console, 'error');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     console.error.restore();
   });
 
-  describe('#shouldIgnoreInjectionError', function () {
+  describe('#shouldIgnoreInjectionError', function() {
     var ignoredErrors = [
       'The tab was closed',
       'No tab with id 42',
       'Cannot access contents of url "file:///C:/t/cpp.pdf". ' +
-      'Extension manifest must request permission to access this host.',
+        'Extension manifest must request permission to access this host.',
       'Cannot access contents of page',
       'The extensions gallery cannot be scripted.',
     ];
 
-    var unexpectedErrors = [
-      'SyntaxError: A typo',
-    ];
+    var unexpectedErrors = ['SyntaxError: A typo'];
 
-    it('should be true for "expected" errors', function () {
-      ignoredErrors.forEach(function (message) {
-        var error = {message: message};
+    it('should be true for "expected" errors', function() {
+      ignoredErrors.forEach(function(message) {
+        var error = { message: message };
         assert.isTrue(errors.shouldIgnoreInjectionError(error));
       });
     });
 
-    it('should be false for unexpected errors', function () {
-      unexpectedErrors.forEach(function (message) {
-        var error = {message: message};
+    it('should be false for unexpected errors', function() {
+      unexpectedErrors.forEach(function(message) {
+        var error = { message: message };
         assert.isFalse(errors.shouldIgnoreInjectionError(error));
       });
     });
 
-    it('should be true for the extension\'s custom error classes', function () {
+    it("should be true for the extension's custom error classes", function() {
       var error = new errors.LocalFileError('some message');
       assert.isTrue(errors.shouldIgnoreInjectionError(error));
     });
   });
 
-  describe('#report', function () {
-    it('reports unknown errors via Raven', function () {
+  describe('#report', function() {
+    it('reports unknown errors via Raven', function() {
       var error = new Error('A most unexpected error');
       errors.report(error, 'injecting the sidebar');
       assert.calledWith(fakeRaven.report, error, 'injecting the sidebar');
     });
 
-    it('does not report known errors via Raven', function () {
+    it('does not report known errors via Raven', function() {
       var error = new errors.LocalFileError('some message');
       errors.report(error, 'injecting the sidebar');
       assert.notCalled(fakeRaven.report);

--- a/tests/common/help-page-test.js
+++ b/tests/common/help-page-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('HelpPage', function () {
+describe('HelpPage', function() {
   var errors = require('../../src/common/errors');
   var HelpPage = require('../../src/common/help-page');
   var fakeBrowserName;
@@ -8,18 +8,21 @@ describe('HelpPage', function () {
   var fakeExtensionURL;
   var help;
 
-  beforeEach(function () {
+  beforeEach(function() {
     fakeBrowserName = sinon.stub().returns('chrome');
-    fakeChromeTabs = {create: sinon.stub()};
-    fakeExtensionURL = function (path) {
+    fakeChromeTabs = { create: sinon.stub() };
+    fakeExtensionURL = function(path) {
       return 'CRX_PATH' + path;
     };
     help = new HelpPage(fakeChromeTabs, fakeExtensionURL, fakeBrowserName);
   });
 
-  describe('.showHelpForError', function () {
-    it('renders the "local-file" page when passed a LocalFileError', function () {
-      help.showHelpForError({id: 1, index: 1}, new errors.LocalFileError('msg'));
+  describe('.showHelpForError', function() {
+    it('renders the "local-file" page when passed a LocalFileError', function() {
+      help.showHelpForError(
+        { id: 1, index: 1 },
+        new errors.LocalFileError('msg')
+      );
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
@@ -28,8 +31,11 @@ describe('HelpPage', function () {
       });
     });
 
-    it('renders the "no-file-access" page when passed a NoFileAccessError', function () {
-      help.showHelpForError({id: 1, index: 1}, new errors.NoFileAccessError('msg'));
+    it('renders the "no-file-access" page when passed a NoFileAccessError', function() {
+      help.showHelpForError(
+        { id: 1, index: 1 },
+        new errors.NoFileAccessError('msg')
+      );
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
@@ -38,8 +44,11 @@ describe('HelpPage', function () {
       });
     });
 
-    it('renders the "no-file-access" page when passed a RestrictedProtocolError', function () {
-      help.showHelpForError({id: 1, index: 1}, new errors.RestrictedProtocolError('msg'));
+    it('renders the "no-file-access" page when passed a RestrictedProtocolError', function() {
+      help.showHelpForError(
+        { id: 1, index: 1 },
+        new errors.RestrictedProtocolError('msg')
+      );
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
@@ -48,8 +57,11 @@ describe('HelpPage', function () {
       });
     });
 
-    it('renders the "blocked-site" page when passed a BlockedSiteError', function () {
-      help.showHelpForError({id: 1, index: 1}, new errors.BlockedSiteError('msg'));
+    it('renders the "blocked-site" page when passed a BlockedSiteError', function() {
+      help.showHelpForError(
+        { id: 1, index: 1 },
+        new errors.BlockedSiteError('msg')
+      );
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
@@ -58,8 +70,8 @@ describe('HelpPage', function () {
       });
     });
 
-    it('renders the "other-error" page for unknown errors', function () {
-      help.showHelpForError({id: 1, index: 1}, new Error('Unexpected Error'));
+    it('renders the "other-error" page for unknown errors', function() {
+      help.showHelpForError({ id: 1, index: 1 }, new Error('Unexpected Error'));
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
@@ -69,9 +81,9 @@ describe('HelpPage', function () {
     });
   });
 
-  describe('.showLocalFileHelpPage', function () {
-    it('should load the help page with the "local-file" fragment', function () {
-      help.showLocalFileHelpPage({id: 1, index: 1});
+  describe('.showLocalFileHelpPage', function() {
+    it('should load the help page with the "local-file" fragment', function() {
+      help.showLocalFileHelpPage({ id: 1, index: 1 });
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
@@ -81,9 +93,9 @@ describe('HelpPage', function () {
     });
   });
 
-  describe('.showNoFileAccessHelpPage', function () {
-    it('should load the help page with the "no-file-access" fragment', function () {
-      help.showNoFileAccessHelpPage({id: 1, index: 1});
+  describe('.showNoFileAccessHelpPage', function() {
+    it('should load the help page with the "no-file-access" fragment', function() {
+      help.showNoFileAccessHelpPage({ id: 1, index: 1 });
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
@@ -93,9 +105,9 @@ describe('HelpPage', function () {
     });
   });
 
-  describe('.showRestrictedProtocolPage', function () {
-    it('should load the help page with the "restricted-protocol" fragment', function () {
-      help.showRestrictedProtocolPage({id: 1, index: 1});
+  describe('.showRestrictedProtocolPage', function() {
+    it('should load the help page with the "restricted-protocol" fragment', function() {
+      help.showRestrictedProtocolPage({ id: 1, index: 1 });
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
@@ -105,11 +117,18 @@ describe('HelpPage', function () {
     });
   });
 
-  context('in Firefox', function () {
-    it('does not set the "openerTabId" argument when creating a new tab', function () {
+  context('in Firefox', function() {
+    it('does not set the "openerTabId" argument when creating a new tab', function() {
       fakeBrowserName.returns('firefox');
-      var help = new HelpPage(fakeChromeTabs, fakeExtensionURL, fakeBrowserName);
-      help.showHelpForError({id: 1, index: 1}, new errors.LocalFileError('msg'));
+      var help = new HelpPage(
+        fakeChromeTabs,
+        fakeExtensionURL,
+        fakeBrowserName
+      );
+      help.showHelpForError(
+        { id: 1, index: 1 },
+        new errors.LocalFileError('msg')
+      );
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,

--- a/tests/common/hypothesis-chrome-extension-test.js
+++ b/tests/common/hypothesis-chrome-extension-test.js
@@ -12,14 +12,13 @@ var TabState = require('../../src/common/tab-state');
 //
 // Used to mock the extension modules
 function createConstructor(prototype) {
-  function Constructor() {
-  }
+  function Constructor() {}
   Constructor.prototype = Object.create(prototype);
   return Constructor;
 }
 
 function FakeListener() {
-  this.addListener = function (callback) {
+  this.addListener = function(callback) {
     this.listener = callback;
   };
 }
@@ -32,7 +31,7 @@ function isValidState(state) {
   return Object.values(TabState.states).indexOf(state.state) !== -1;
 }
 
-describe('HypothesisChromeExtension', function () {
+describe('HypothesisChromeExtension', function() {
   var sandbox = sinon.sandbox.create();
   var HypothesisChromeExtension;
   var ext;
@@ -58,10 +57,10 @@ describe('HypothesisChromeExtension', function () {
     });
   }
 
-  beforeEach(function () {
+  beforeEach(function() {
     fakeChromeStorage = {
       sync: {
-        get: sandbox.stub().callsArgWith(1, {badge: true}),
+        get: sandbox.stub().callsArgWith(1, { badge: true }),
       },
     };
     fakeChromeTabs = {
@@ -76,7 +75,7 @@ describe('HypothesisChromeExtension', function () {
       onClicked: new FakeListener(),
     };
     fakeChromeExtension = {
-      getURL: function (path) {
+      getURL: function(path) {
         return 'chrome://1234' + path;
       },
     };
@@ -112,7 +111,9 @@ describe('HypothesisChromeExtension', function () {
       removeFromTab: sandbox.stub().returns(Promise.resolve()),
     };
     fakeErrors = {
-      shouldIgnoreInjectionError: function () { return false; },
+      shouldIgnoreInjectionError: function() {
+        return false;
+      },
       report: sandbox.spy(),
     };
 
@@ -121,60 +122,63 @@ describe('HypothesisChromeExtension', function () {
     }
     FakeTabState.prototype = fakeTabState;
 
-    HypothesisChromeExtension = proxyquire('../../src/common/hypothesis-chrome-extension', {
-      './tab-state': FakeTabState,
-      './tab-store': createConstructor(fakeTabStore),
-      './help-page': createConstructor(fakeHelpPage),
-      './browser-action': createConstructor(fakeBrowserAction),
-      './sidebar-injector': createConstructor(fakeSidebarInjector),
-      './errors': fakeErrors,
-      './settings': {
-        serviceUrl: 'https://hypothes.is/',
-      },
-    });
+    HypothesisChromeExtension = proxyquire(
+      '../../src/common/hypothesis-chrome-extension',
+      {
+        './tab-state': FakeTabState,
+        './tab-store': createConstructor(fakeTabStore),
+        './help-page': createConstructor(fakeHelpPage),
+        './browser-action': createConstructor(fakeBrowserAction),
+        './sidebar-injector': createConstructor(fakeSidebarInjector),
+        './errors': fakeErrors,
+        './settings': {
+          serviceUrl: 'https://hypothes.is/',
+        },
+      }
+    );
 
     ext = createExt();
   });
 
-  afterEach(function () {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  describe('.install', function () {
+  describe('.install', function() {
     var tabs;
     var savedState;
 
-    beforeEach(function () {
+    beforeEach(function() {
       tabs = [];
-      savedState =  {
+      savedState = {
         1: {
           state: TabState.states.ACTIVE,
         },
       };
-      tabs.push({id: 1, url: 'http://example.com'});
+      tabs.push({ id: 1, url: 'http://example.com' });
       fakeChromeTabs.query = sandbox.stub().yields(tabs);
       fakeTabStore.all = sandbox.stub().returns(savedState);
     });
 
-    it('restores the saved tab states', function () {
+    it('restores the saved tab states', function() {
       ext.install();
       assert.called(fakeTabStore.reload);
       assert.calledWith(fakeTabState.load, savedState);
     });
 
-    it('applies the saved state to open tabs', function () {
+    it('applies the saved state to open tabs', function() {
       fakeTabState.getState = sandbox.stub().returns(savedState[1]);
       ext.install();
       assert.calledWith(fakeBrowserAction.update, 1, savedState[1]);
     });
   });
 
-  describe('.firstRun', function () {
-    beforeEach(function () {
-      fakeChromeTabs.create = sandbox.stub().yields({id: 1});
+  describe('.firstRun', function() {
+    beforeEach(function() {
+      fakeChromeTabs.create = sandbox.stub().yields({ id: 1 });
     });
 
-    it('opens a new tab pointing to the welcome page', function () {
+    it('opens a new tab pointing to the welcome page', function() {
       ext.firstRun({});
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
@@ -182,22 +186,22 @@ describe('HypothesisChromeExtension', function () {
       });
     });
 
-    it('sets the browser state to active', function () {
+    it('sets the browser state to active', function() {
       ext.firstRun({});
       assert.called(fakeTabState.activateTab);
       assert.calledWith(fakeTabState.activateTab, 1);
     });
 
-    it('does not open a new tab for administrative installs', function () {
-      ext.firstRun({installType: 'admin'});
+    it('does not open a new tab for administrative installs', function() {
+      ext.firstRun({ installType: 'admin' });
       assert.notCalled(fakeChromeTabs.create);
       assert.notCalled(fakeTabState.activateTab);
     });
   });
 
-  describe('.listen', function () {
-    it('sets up event listeners', function () {
-      ext.listen({addEventListener: sandbox.stub()});
+  describe('.listen', function() {
+    it('sets up event listeners', function() {
+      ext.listen({ addEventListener: sandbox.stub() });
       assert.ok(fakeChromeBrowserAction.onClicked.listener);
       assert.ok(fakeChromeTabs.onCreated.listener);
       assert.ok(fakeChromeTabs.onUpdated.listener);
@@ -205,132 +209,151 @@ describe('HypothesisChromeExtension', function () {
       assert.ok(fakeChromeTabs.onReplaced.listener);
     });
 
-    describe('when a tab is created', function () {
-      beforeEach(function () {
+    describe('when a tab is created', function() {
+      beforeEach(function() {
         fakeTabState.clearTab = sandbox.spy();
-        ext.listen({addEventListener: sandbox.stub()});
+        ext.listen({ addEventListener: sandbox.stub() });
       });
 
-      it('clears the new tab state', function () {
-        fakeChromeTabs.onCreated.listener({id: 1, url: 'http://example.com/foo.html'});
+      it('clears the new tab state', function() {
+        fakeChromeTabs.onCreated.listener({
+          id: 1,
+          url: 'http://example.com/foo.html',
+        });
         assert.calledWith(fakeTabState.clearTab, 1);
       });
     });
 
-    describe('when a tab is updated', function () {
+    describe('when a tab is updated', function() {
       var tabState = {};
       function createTab(initialState) {
         var tabId = 1;
-        tabState[tabId] = Object.assign({
-          state: TabState.states.INACTIVE,
-          annotationCount: 0,
-          ready: false,
-        }, initialState);
-        return {id: tabId, url: 'http://example.com/foo.html', status: 'complete'};
+        tabState[tabId] = Object.assign(
+          {
+            state: TabState.states.INACTIVE,
+            annotationCount: 0,
+            ready: false,
+          },
+          initialState
+        );
+        return {
+          id: tabId,
+          url: 'http://example.com/foo.html',
+          status: 'complete',
+        };
       }
 
-      beforeEach(function () {
+      beforeEach(function() {
         fakeTabState.clearTab = sandbox.spy();
-        fakeTabState.isTabActive = function (tabId) {
+        fakeTabState.isTabActive = function(tabId) {
           return tabState[tabId].state === TabState.states.ACTIVE;
         };
-        fakeTabState.isTabErrored = function (tabId) {
+        fakeTabState.isTabErrored = function(tabId) {
           return tabState[tabId].state === TabState.states.ERRORED;
         };
-        fakeTabState.getState = function (tabId) {
+        fakeTabState.getState = function(tabId) {
           return tabState[tabId];
         };
-        fakeTabState.setState = function (tabId, state) {
+        fakeTabState.setState = function(tabId, state) {
           tabState[tabId] = Object.assign(tabState[tabId], state);
           assert(isValidState(tabState[tabId]));
         };
-        ext.listen({addEventListener: sandbox.stub()});
+        ext.listen({ addEventListener: sandbox.stub() });
       });
 
-      it('sets the tab state to ready when loading completes', function () {
-        var tab = createTab({state: TabState.states.ACTIVE});
-        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
+      it('sets the tab state to ready when loading completes', function() {
+        var tab = createTab({ state: TabState.states.ACTIVE });
+        fakeChromeTabs.onUpdated.listener(tab.id, { status: 'complete' }, tab);
         assert.equal(tabState[tab.id].ready, true);
       });
 
-      it('resets the tab state when loading', function () {
+      it('resets the tab state when loading', function() {
         var tab = createTab({
           state: TabState.states.ACTIVE,
           ready: true,
           extensionSidebarInstalled: true,
         });
-        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, { status: 'loading' }, tab);
         assert.equal(tabState[tab.id].ready, false);
         assert.equal(tabState[tab.id].extensionSidebarInstalled, false);
       });
 
-      it('resets the tab state to active if errored', function () {
-        var tab = createTab({state: TabState.states.ERRORED});
-        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
+      it('resets the tab state to active if errored', function() {
+        var tab = createTab({ state: TabState.states.ERRORED });
+        fakeChromeTabs.onUpdated.listener(tab.id, { status: 'loading' }, tab);
         assert.equal(tabState[tab.id].state, TabState.states.ACTIVE);
       });
 
-      [
-        '#annotations:456',
-        '#annotations:query:blah',
-      ].forEach((fragment) => {
-        it('injects the sidebar if a direct link is present', function () {
+      ['#annotations:456', '#annotations:query:blah'].forEach(fragment => {
+        it('injects the sidebar if a direct link is present', function() {
           var tab = createTab();
           tab.url += fragment;
-          fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
-          fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
+          fakeChromeTabs.onUpdated.listener(tab.id, { status: 'loading' }, tab);
+          fakeChromeTabs.onUpdated.listener(
+            tab.id,
+            { status: 'complete' },
+            tab
+          );
           assert.equal(tabState[tab.id].state, TabState.states.ACTIVE);
         });
       });
 
-      it('injects the sidebar if the page rewrites the URL fragment', function () {
+      it('injects the sidebar if the page rewrites the URL fragment', function() {
         var tab = createTab();
         var origURL = tab.url;
         tab.url += '#annotations:456';
-        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, { status: 'loading' }, tab);
 
         // Simulate client side JS rewriting the URL fragment before the sidebar
         // is injected
         tab.url = origURL + '#modified-fragment';
-        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
-        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, { status: 'loading' }, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, { status: 'complete' }, tab);
         assert.equal(tabState[tab.id].state, TabState.states.ACTIVE);
       });
 
-      it('updates the badge count', function () {
+      it('updates the badge count', function() {
         var tab = createTab();
-        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
-        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
-        assert.calledWith(fakeTabState.updateAnnotationCount, tab.id, 'http://example.com/foo.html');
+        fakeChromeTabs.onUpdated.listener(tab.id, { status: 'loading' }, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, { status: 'complete' }, tab);
+        assert.calledWith(
+          fakeTabState.updateAnnotationCount,
+          tab.id,
+          'http://example.com/foo.html'
+        );
       });
 
-      it('updates the badge count if "chrome.storage.sync" is not supported', function () {
+      it('updates the badge count if "chrome.storage.sync" is not supported', function() {
         var tab = createTab();
         delete fakeChromeStorage.sync;
 
-        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
-        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, { status: 'loading' }, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, { status: 'complete' }, tab);
 
-        assert.calledWith(fakeTabState.updateAnnotationCount, tab.id, 'http://example.com/foo.html');
+        assert.calledWith(
+          fakeTabState.updateAnnotationCount,
+          tab.id,
+          'http://example.com/foo.html'
+        );
       });
 
-      it('does not update the badge count if the option is disabled', function () {
+      it('does not update the badge count if the option is disabled', function() {
         var tab = createTab();
-        fakeChromeStorage.sync.get.callsArgWith(1, {badge: false});
+        fakeChromeStorage.sync.get.callsArgWith(1, { badge: false });
 
-        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
-        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, { status: 'loading' }, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, { status: 'complete' }, tab);
 
         assert.notCalled(fakeTabState.updateAnnotationCount);
       });
     });
 
-    describe('when a tab is replaced', function () {
-      beforeEach(function () {
-        ext.listen({addEventListener: sandbox.stub()});
+    describe('when a tab is replaced', function() {
+      beforeEach(function() {
+        ext.listen({ addEventListener: sandbox.stub() });
       });
 
-      it('preserves the active state of the previous tab', function () {
+      it('preserves the active state of the previous tab', function() {
         fakeTabState.getState = sandbox.stub().returns({
           state: TabState.states.ACTIVE,
         });
@@ -342,7 +365,7 @@ describe('HypothesisChromeExtension', function () {
         });
       });
 
-      it('reactivates errored tabs', function () {
+      it('reactivates errored tabs', function() {
         fakeTabState.getState = sandbox.stub().returns({
           state: TabState.states.ERRORED,
         });
@@ -354,48 +377,54 @@ describe('HypothesisChromeExtension', function () {
       });
     });
 
-    describe('when a tab is removed', function () {
-      beforeEach(function () {
+    describe('when a tab is removed', function() {
+      beforeEach(function() {
         fakeTabState.clearTab = sandbox.spy();
-        ext.listen({addEventListener: sandbox.stub()});
+        ext.listen({ addEventListener: sandbox.stub() });
       });
 
-      it('clears the tab', function () {
+      it('clears the tab', function() {
         fakeChromeTabs.onRemoved.listener(1);
         assert.calledWith(fakeTabState.clearTab, 1);
       });
     });
 
-    describe('when the browser icon is clicked', function () {
-      beforeEach(function () {
-        ext.listen({addEventListener: sandbox.stub()});
+    describe('when the browser icon is clicked', function() {
+      beforeEach(function() {
+        ext.listen({ addEventListener: sandbox.stub() });
       });
 
-      it('activate the tab if the tab is inactive', function () {
+      it('activate the tab if the tab is inactive', function() {
         fakeTabState.isTabInactive.returns(true);
-        fakeChromeBrowserAction.onClicked.listener({id: 1, url: 'http://example.com/foo.html'});
+        fakeChromeBrowserAction.onClicked.listener({
+          id: 1,
+          url: 'http://example.com/foo.html',
+        });
         assert.called(fakeTabState.activateTab);
         assert.calledWith(fakeTabState.activateTab, 1);
       });
 
-      it('deactivate the tab if the tab is active', function () {
+      it('deactivate the tab if the tab is active', function() {
         fakeTabState.isTabActive.returns(true);
-        fakeChromeBrowserAction.onClicked.listener({id: 1, url: 'http://example.com/foo.html'});
+        fakeChromeBrowserAction.onClicked.listener({
+          id: 1,
+          url: 'http://example.com/foo.html',
+        });
         assert.called(fakeTabState.deactivateTab);
         assert.calledWith(fakeTabState.deactivateTab, 1);
       });
     });
   });
 
-  describe('when injection fails', function () {
+  describe('when injection fails', function() {
     function triggerInstall() {
-      var tab = {id: 1, url: 'file://foo.html', status: 'complete'};
+      var tab = { id: 1, url: 'file://foo.html', status: 'complete' };
       var tabState = {
         state: TabState.states.ACTIVE,
         extensionSidebarInstalled: false,
         ready: true,
       };
-      fakeChromeTabs.get = function (tabId, callback) {
+      fakeChromeTabs.get = function(tabId, callback) {
         callback(tab);
       };
       fakeTabState.isTabActive.withArgs(1).returns(true);
@@ -403,8 +432,8 @@ describe('HypothesisChromeExtension', function () {
       fakeTabState.onChangeHandler(tab.id, tabState, null);
     }
 
-    beforeEach(function () {
-      ext.listen({addEventListener: sandbox.stub()});
+    beforeEach(function() {
+      ext.listen({ addEventListener: sandbox.stub() });
     });
 
     var injectErrorCases = [
@@ -413,22 +442,22 @@ describe('HypothesisChromeExtension', function () {
       errors.RestrictedProtocolError,
     ];
 
-    injectErrorCases.forEach(function (ErrorType) {
-      describe('with ' + ErrorType.name, function () {
-        it('puts the tab into an errored state', function () {
+    injectErrorCases.forEach(function(ErrorType) {
+      describe('with ' + ErrorType.name, function() {
+        it('puts the tab into an errored state', function() {
           var injectError = Promise.reject(new ErrorType('msg'));
           fakeSidebarInjector.injectIntoTab.returns(injectError);
 
           triggerInstall();
 
-          return toResult(injectError).then(function () {
+          return toResult(injectError).then(function() {
             assert.called(fakeTabState.errorTab);
             assert.calledWith(fakeTabState.errorTab, 1);
           });
         });
 
-        it('shows the help page for ' + ErrorType.name, function () {
-          var tab = {id: 1, url: 'file://foo.html'};
+        it('shows the help page for ' + ErrorType.name, function() {
+          var tab = { id: 1, url: 'file://foo.html' };
 
           fakeTabState.getState.returns({
             state: TabState.states.ERRORED,
@@ -438,13 +467,16 @@ describe('HypothesisChromeExtension', function () {
           fakeChromeBrowserAction.onClicked.listener(tab);
 
           assert.called(fakeHelpPage.showHelpForError);
-          assert.calledWith(fakeHelpPage.showHelpForError, tab,
-            sinon.match.instanceOf(ErrorType));
+          assert.calledWith(
+            fakeHelpPage.showHelpForError,
+            tab,
+            sinon.match.instanceOf(ErrorType)
+          );
         });
 
-        it('does not log known errors', function () {
+        it('does not log known errors', function() {
           var error = new Error('Some error');
-          fakeErrors.shouldIgnoreInjectionError = function () {
+          fakeErrors.shouldIgnoreInjectionError = function() {
             return true;
           };
           var injectError = Promise.reject(error);
@@ -452,20 +484,21 @@ describe('HypothesisChromeExtension', function () {
 
           triggerInstall();
 
-          return toResult(injectError).then(function () {
+          return toResult(injectError).then(function() {
             assert.notCalled(fakeErrors.report);
           });
         });
 
-        it('logs unexpected errors', function () {
+        it('logs unexpected errors', function() {
           var error = new ErrorType('msg');
           var injectError = Promise.reject(error);
           fakeSidebarInjector.injectIntoTab.returns(injectError);
 
           triggerInstall();
 
-          return toResult(injectError).then(function () {
-            assert.calledWith(fakeErrors.report,
+          return toResult(injectError).then(function() {
+            assert.calledWith(
+              fakeErrors.report,
               error,
               'Injecting Hypothesis sidebar',
               { url: 'file://foo.html' }
@@ -476,7 +509,7 @@ describe('HypothesisChromeExtension', function () {
     });
   });
 
-  describe('TabState.onchange', function () {
+  describe('TabState.onchange', function() {
     var tabStates = TabState.states;
 
     var onChangeHandler;
@@ -484,20 +517,28 @@ describe('HypothesisChromeExtension', function () {
 
     // simulate a tab state change from 'prev' to 'current'
     function onTabStateChange(current, prev) {
-      onChangeHandler(1, current ? {
-        state: current,
-      } : null, prev ? {
-        state: prev,
-      } : null);
+      onChangeHandler(
+        1,
+        current
+          ? {
+              state: current,
+            }
+          : null,
+        prev
+          ? {
+              state: prev,
+            }
+          : null
+      );
     }
 
-    beforeEach(function () {
-      tab = {id: 1, status: 'complete'};
+    beforeEach(function() {
+      tab = { id: 1, status: 'complete' };
       fakeChromeTabs.get = sandbox.stub().yields(tab);
       onChangeHandler = ext._onTabStateChange;
     });
 
-    it('updates the browser icon', function () {
+    it('updates the browser icon', function() {
       fakeTabState.getState = sandbox.stub().returns({
         state: tabStates.ACTIVE,
       });
@@ -507,7 +548,7 @@ describe('HypothesisChromeExtension', function () {
       });
     });
 
-    it('updates the TabStore if the tab has not errored', function () {
+    it('updates the TabStore if the tab has not errored', function() {
       fakeTabState.getState = sandbox.stub().returns({
         state: tabStates.ACTIVE,
       });
@@ -517,13 +558,13 @@ describe('HypothesisChromeExtension', function () {
       });
     });
 
-    it('does not update the TabStore if the tab has errored', function () {
+    it('does not update the TabStore if the tab has errored', function() {
       fakeTabState.isTabErrored.returns(true);
       onTabStateChange(tabStates.ERRORED, tabStates.INACTIVE);
       assert.notCalled(fakeTabStore.set);
     });
 
-    it('injects the sidebar if the tab has been activated', function () {
+    it('injects the sidebar if the tab has been activated', function() {
       fakeTabState.getState = sandbox.stub().returns({
         state: tabStates.ACTIVE,
         ready: true,
@@ -533,7 +574,7 @@ describe('HypothesisChromeExtension', function () {
       assert.calledWith(fakeSidebarInjector.injectIntoTab, tab);
     });
 
-    it('configures the client to load assets from the extension', function () {
+    it('configures the client to load assets from the extension', function() {
       fakeTabState.getState = sandbox.stub().returns({
         state: tabStates.ACTIVE,
         ready: true,
@@ -546,7 +587,7 @@ describe('HypothesisChromeExtension', function () {
       });
     });
 
-    it('does not inject the sidebar if already installed', function () {
+    it('does not inject the sidebar if already installed', function() {
       fakeTabState.getState = sandbox.stub().returns({
         state: tabStates.ACTIVE,
         extensionSidebarInstalled: true,
@@ -557,7 +598,7 @@ describe('HypothesisChromeExtension', function () {
       assert.notCalled(fakeSidebarInjector.injectIntoTab);
     });
 
-    it('removes the sidebar if the tab has been deactivated', function () {
+    it('removes the sidebar if the tab has been deactivated', function() {
       fakeTabState.getState = sandbox.stub().returns({
         state: tabStates.INACTIVE,
         extensionSidebarInstalled: true,
@@ -572,26 +613,26 @@ describe('HypothesisChromeExtension', function () {
       assert.calledWith(fakeSidebarInjector.removeFromTab, tab);
     });
 
-    it('does not remove the sidebar if not installed', function () {
+    it('does not remove the sidebar if not installed', function() {
       fakeTabState.getState = sandbox.stub().returns({
         state: tabStates.INACTIVE,
         extensionSidebarInstalled: false,
         ready: true,
       });
       fakeTabState.isTabInactive.returns(true);
-      fakeChromeTabs.get = sandbox.stub().yields({id: 1, status: 'complete'});
+      fakeChromeTabs.get = sandbox.stub().yields({ id: 1, status: 'complete' });
       onTabStateChange(tabStates.INACTIVE, tabStates.ACTIVE);
       assert.notCalled(fakeSidebarInjector.removeFromTab);
     });
 
-    it('does nothing with the sidebar if the tab is errored', function () {
+    it('does nothing with the sidebar if the tab is errored', function() {
       fakeTabState.isTabErrored.returns(true);
       onTabStateChange(tabStates.ERRORED, tabStates.INACTIVE);
       assert.notCalled(fakeSidebarInjector.injectIntoTab);
       assert.notCalled(fakeSidebarInjector.removeFromTab);
     });
 
-    it('does nothing if the tab is still loading', function () {
+    it('does nothing if the tab is still loading', function() {
       fakeTabState.getState = sandbox.stub().returns({
         state: tabStates.ACTIVE,
         extensionSidebarInstalled: false,
@@ -601,7 +642,7 @@ describe('HypothesisChromeExtension', function () {
       assert.notCalled(fakeSidebarInjector.injectIntoTab);
     });
 
-    it('removes the tab from the store if the tab was closed', function () {
+    it('removes the tab from the store if the tab was closed', function() {
       onTabStateChange(null, tabStates.INACTIVE);
       assert.called(fakeTabStore.unset);
       assert.calledWith(fakeTabStore.unset);

--- a/tests/common/install-test.js
+++ b/tests/common/install-test.js
@@ -19,11 +19,11 @@ function eventListenerStub() {
   };
 }
 
-describe('install', function () {
+describe('install', function() {
   var origChrome;
   var fakeChrome;
 
-  beforeEach(function () {
+  beforeEach(function() {
     fakeChrome = {
       tabs: {},
       browserAction: {},
@@ -39,8 +39,8 @@ describe('install', function () {
         onUpdateAvailable: eventListenerStub(),
       },
       management: {
-        getSelf: function (cb) {
-          cb({installType: 'normal', id: '1234'});
+        getSelf: function(cb) {
+          cb({ installType: 'normal', id: '1234' });
         },
       },
     };
@@ -56,19 +56,22 @@ describe('install', function () {
     });
   });
 
-  afterEach(function () {
+  afterEach(function() {
     window.chrome = origChrome;
   });
 
-  context('when the extension is installed', function () {
+  context('when the extension is installed', function() {
     function triggerInstallEvent() {
       var cb = fakeChrome.runtime.onInstalled.addListener.args[0][0];
-      cb({reason: 'install'});
+      cb({ reason: 'install' });
     }
 
-    it("calls the extension's first run hook", function () {
+    it("calls the extension's first run hook", function() {
       triggerInstallEvent();
-      assert.calledWith(extension.firstRun, {id: '1234', installType: 'normal'});
+      assert.calledWith(extension.firstRun, {
+        id: '1234',
+        installType: 'normal',
+      });
     });
   });
 });

--- a/tests/common/sidebar-injector-test.js
+++ b/tests/common/sidebar-injector-test.js
@@ -15,14 +15,14 @@ var PDF_VIEWER_BASE_URL = EXTENSION_BASE_URL + '/content/web/viewer.html?file=';
 function createTestFrame() {
   var frame = document.createElement('iframe');
   document.body.appendChild(frame);
-  frame.contentDocument.body.appendChild = function () {
+  frame.contentDocument.body.appendChild = function() {
     // no-op to avoid trying to actually load <script> tags injected into
     // the page
   };
   return frame;
 }
 
-describe('SidebarInjector', function () {
+describe('SidebarInjector', function() {
   var errors = require('../../src/common/errors');
   var SidebarInjector = require('../../src/common/sidebar-injector');
   var injector;
@@ -43,7 +43,7 @@ describe('SidebarInjector', function () {
   // Mock return value from embed.js when injected into page
   var embedScriptReturnValue;
 
-  beforeEach(function () {
+  beforeEach(function() {
     contentType = 'HTML';
     isAlreadyInjected = false;
     contentFrame = undefined;
@@ -51,13 +51,13 @@ describe('SidebarInjector', function () {
       installedURL: EXTENSION_BASE_URL + '/client/app.html',
     };
 
-    var executeScriptSpy = sinon.spy(function (tabId, details, callback) {
+    var executeScriptSpy = sinon.spy(function(tabId, details, callback) {
       if (contentFrame) {
         contentFrame.contentWindow.eval(details.code);
       }
 
       if (details.code && details.code.match(/detectContentType/)) {
-        callback([{type: contentType}]);
+        callback([{ type: contentType }]);
       } else if (details.file && details.file.match(/boot/)) {
         callback([embedScriptReturnValue]);
       } else if (details.file && details.file.match(/destroy/)) {
@@ -75,63 +75,67 @@ describe('SidebarInjector', function () {
 
     injector = new SidebarInjector(fakeChromeTabs, {
       isAllowedFileSchemeAccess: fakeFileAccess,
-      extensionURL: sinon.spy(function (path) {
+      extensionURL: sinon.spy(function(path) {
         return EXTENSION_BASE_URL + path;
       }),
     });
   });
 
-  afterEach(function () {
+  afterEach(function() {
     if (contentFrame) {
       contentFrame.parentNode.removeChild(contentFrame);
     }
   });
 
-  describe('.injectIntoTab', function () {
+  describe('.injectIntoTab', function() {
     var urls = [
       'chrome://version',
       'chrome-devtools://host',
       'chrome-extension://1234/foo.html',
       'chrome-extension://1234/foo.pdf',
     ];
-    urls.forEach(function (url) {
-      it('bails early when trying to load an unsupported url: ' + url, function () {
-        var spy = fakeChromeTabs.executeScript;
-        return toResult(injector.injectIntoTab({id: 1, url: url}))
-          .then(function (result) {
-            assert.ok(result.error);
-            assert.instanceOf(result.error, errors.RestrictedProtocolError);
-            assert.notCalled(spy);
-          });
-      });
+    urls.forEach(function(url) {
+      it(
+        'bails early when trying to load an unsupported url: ' + url,
+        function() {
+          var spy = fakeChromeTabs.executeScript;
+          return toResult(injector.injectIntoTab({ id: 1, url: url })).then(
+            function(result) {
+              assert.ok(result.error);
+              assert.instanceOf(result.error, errors.RestrictedProtocolError);
+              assert.notCalled(spy);
+            }
+          );
+        }
+      );
     });
 
-    it('succeeds if the tab is already displaying the embedded PDF viewer', function () {
-      var url = PDF_VIEWER_BASE_URL +
-          encodeURIComponent('http://origin/foo.pdf');
-      return injector.injectIntoTab({id: 1, url: url});
-    }
-    );
+    it('succeeds if the tab is already displaying the embedded PDF viewer', function() {
+      var url =
+        PDF_VIEWER_BASE_URL + encodeURIComponent('http://origin/foo.pdf');
+      return injector.injectIntoTab({ id: 1, url: url });
+    });
 
-    describe('when viewing a remote PDF', function () {
+    describe('when viewing a remote PDF', function() {
       var url = 'http://example.com/foo.pdf';
 
-      it('injects hypothesis into the page', function () {
+      it('injects hypothesis into the page', function() {
         contentType = 'PDF';
-        var spy = fakeChromeTabs.update.yields({tab: 1});
-        return injector.injectIntoTab({id: 1, url: url}).then(function() {
+        var spy = fakeChromeTabs.update.yields({ tab: 1 });
+        return injector.injectIntoTab({ id: 1, url: url }).then(function() {
           assert.calledWith(spy, 1, {
             url: PDF_VIEWER_BASE_URL + encodeURIComponent(url),
           });
         });
       });
 
-      it('preserves #annotations fragments in the URL', function () {
+      it('preserves #annotations fragments in the URL', function() {
         contentType = 'PDF';
-        var spy = fakeChromeTabs.update.yields({tab: 1});
+        var spy = fakeChromeTabs.update.yields({ tab: 1 });
         var hash = '#annotations:456';
-        return injector.injectIntoTab({id: 1, url: url + hash})
-          .then(function () {
+        return injector
+          .injectIntoTab({ id: 1, url: url + hash })
+          .then(function() {
             assert.calledWith(spy, 1, {
               url: PDF_VIEWER_BASE_URL + encodeURIComponent(url) + hash,
             });
@@ -139,82 +143,86 @@ describe('SidebarInjector', function () {
       });
     });
 
-    describe('when viewing a remote HTML page', function () {
-      it('injects hypothesis into the page', function () {
+    describe('when viewing a remote HTML page', function() {
+      it('injects hypothesis into the page', function() {
         var spy = fakeChromeTabs.executeScript;
         var url = 'http://example.com/foo.html';
 
-        return injector.injectIntoTab({id: 1, url: url}).then(function() {
+        return injector.injectIntoTab({ id: 1, url: url }).then(function() {
           assert.calledWith(spy, 1, {
             file: sinon.match('/client/build/boot.js'),
           });
         });
       });
 
-      it('reports an error if Hypothesis is already embedded', function () {
-        embedScriptReturnValue = {installedURL: 'https://hypothes.is/app.html'};
+      it('reports an error if Hypothesis is already embedded', function() {
+        embedScriptReturnValue = {
+          installedURL: 'https://hypothes.is/app.html',
+        };
         var url = 'http://example.com';
-        return toResult(injector.injectIntoTab({id: 1, url: url}))
-          .then(function (result) {
+        return toResult(injector.injectIntoTab({ id: 1, url: url })).then(
+          function(result) {
             assert.ok(result.error);
             assert.instanceOf(result.error, errors.AlreadyInjectedError);
-          });
+          }
+        );
       });
 
-      it('injects config options into the page', function () {
+      it('injects config options into the page', function() {
         contentFrame = createTestFrame();
         var url = 'http://example.com';
-        return injector.injectIntoTab({id: 1, url: url}, {annotations:'456'})
-          .then(function () {
-            var configEl = contentFrame.contentDocument
-              .querySelector('script.js-hypothesis-config');
+        return injector
+          .injectIntoTab({ id: 1, url: url }, { annotations: '456' })
+          .then(function() {
+            var configEl = contentFrame.contentDocument.querySelector(
+              'script.js-hypothesis-config'
+            );
             assert.ok(configEl);
-            assert.deepEqual(JSON.parse(configEl.textContent),
-              {annotations:'456'});
+            assert.deepEqual(JSON.parse(configEl.textContent), {
+              annotations: '456',
+            });
           });
       });
     });
 
-    describe('when viewing a local PDF', function () {
-      describe('when file access is enabled', function () {
-        it('loads the PDFjs viewer', function () {
+    describe('when viewing a local PDF', function() {
+      describe('when file access is enabled', function() {
+        it('loads the PDFjs viewer', function() {
           var spy = fakeChromeTabs.update.yields([]);
           var url = 'file:///foo.pdf';
           contentType = 'PDF';
 
-          return injector.injectIntoTab({id: 1, url: url}).then(
-            function () {
-              assert.called(spy);
-              assert.calledWith(spy, 1, {
-                url: PDF_VIEWER_BASE_URL + encodeURIComponent('file:///foo.pdf'),
-              });
-            }
-          );
+          return injector.injectIntoTab({ id: 1, url: url }).then(function() {
+            assert.called(spy);
+            assert.calledWith(spy, 1, {
+              url: PDF_VIEWER_BASE_URL + encodeURIComponent('file:///foo.pdf'),
+            });
+          });
         });
       });
 
-      describe('when file access is disabled', function () {
-        beforeEach(function () {
+      describe('when file access is disabled', function() {
+        beforeEach(function() {
           fakeFileAccess.yields(false);
           contentType = 'PDF';
         });
 
-        it('returns an error', function () {
+        it('returns an error', function() {
           var url = 'file://foo.pdf';
 
-          var promise = injector.injectIntoTab({id: 1, url: url});
-          return toResult(promise).then(function (result) {
+          var promise = injector.injectIntoTab({ id: 1, url: url });
+          return toResult(promise).then(function(result) {
             assert.instanceOf(result.error, errors.NoFileAccessError);
             assert.notCalled(fakeChromeTabs.executeScript);
           });
         });
       });
 
-      describe('when viewing a local HTML file', function () {
-        it('returns an error', function () {
+      describe('when viewing a local HTML file', function() {
+        it('returns an error', function() {
           var url = 'file://foo.html';
-          var promise = injector.injectIntoTab({id: 1, url: url});
-          return toResult(promise).then(function (result) {
+          var promise = injector.injectIntoTab({ id: 1, url: url });
+          return toResult(promise).then(function(result) {
             assert.instanceOf(result.error, errors.LocalFileError);
           });
         });
@@ -222,45 +230,52 @@ describe('SidebarInjector', function () {
     });
   });
 
-  describe('.removeFromTab', function () {
-    it('bails early when trying to unload a chrome url', function () {
+  describe('.removeFromTab', function() {
+    it('bails early when trying to unload a chrome url', function() {
       var spy = fakeChromeTabs.executeScript;
       var url = 'chrome://extensions/';
 
-      return injector.removeFromTab({id: 1, url: url}).then(function () {
+      return injector.removeFromTab({ id: 1, url: url }).then(function() {
         assert.notCalled(spy);
       });
     });
 
     var protocols = ['chrome:', 'chrome-devtools:', 'chrome-extension:'];
-    protocols.forEach(function (protocol) {
-      it('bails early when trying to unload an unsupported ' + protocol + ' url', function () {
-        var spy = fakeChromeTabs.executeScript;
-        var url = protocol + '//foobar/';
+    protocols.forEach(function(protocol) {
+      it(
+        'bails early when trying to unload an unsupported ' + protocol + ' url',
+        function() {
+          var spy = fakeChromeTabs.executeScript;
+          var url = protocol + '//foobar/';
 
-        return injector.removeFromTab({id: 1, url: url}).then(function () {
-          assert.notCalled(spy);
-        });
-      });
+          return injector.removeFromTab({ id: 1, url: url }).then(function() {
+            assert.notCalled(spy);
+          });
+        }
+      );
     });
 
-    describe('when viewing a PDF', function () {
-      it('reverts the tab back to the original document', function () {
+    describe('when viewing a PDF', function() {
+      it('reverts the tab back to the original document', function() {
         var spy = fakeChromeTabs.update.yields([]);
-        var url = PDF_VIEWER_BASE_URL +
-          encodeURIComponent('http://example.com/foo.pdf') + '#foo';
-        return injector.removeFromTab({id: 1, url: url}).then(function () {
+        var url =
+          PDF_VIEWER_BASE_URL +
+          encodeURIComponent('http://example.com/foo.pdf') +
+          '#foo';
+        return injector.removeFromTab({ id: 1, url: url }).then(function() {
           assert.calledWith(spy, 1, {
             url: 'http://example.com/foo.pdf#foo',
           });
         });
       });
 
-      it('drops #annotations fragments', function () {
+      it('drops #annotations fragments', function() {
         var spy = fakeChromeTabs.update.yields([]);
-        var url = PDF_VIEWER_BASE_URL +
-          encodeURIComponent('http://example.com/foo.pdf') + '#annotations:456';
-        return injector.removeFromTab({id: 1, url: url}).then(function () {
+        var url =
+          PDF_VIEWER_BASE_URL +
+          encodeURIComponent('http://example.com/foo.pdf') +
+          '#annotations:456';
+        return injector.removeFromTab({ id: 1, url: url }).then(function() {
           assert.calledWith(spy, 1, {
             url: 'http://example.com/foo.pdf',
           });
@@ -268,14 +283,16 @@ describe('SidebarInjector', function () {
       });
     });
 
-    describe('when viewing an HTML page', function () {
-      it('injects a destroy script into the page', function () {
+    describe('when viewing an HTML page', function() {
+      it('injects a destroy script into the page', function() {
         isAlreadyInjected = true;
-        return injector.removeFromTab({id: 1, url: 'http://example.com/foo.html'}).then(function () {
-          assert.calledWith(fakeChromeTabs.executeScript, 1, {
-            file: sinon.match('/lib/destroy.js'),
+        return injector
+          .removeFromTab({ id: 1, url: 'http://example.com/foo.html' })
+          .then(function() {
+            assert.calledWith(fakeChromeTabs.executeScript, 1, {
+              file: sinon.match('/lib/destroy.js'),
+            });
           });
-        });
       });
     });
   });

--- a/tests/common/tab-state-test.js
+++ b/tests/common/tab-state-test.js
@@ -4,162 +4,177 @@ var proxyquire = require('proxyquire');
 
 var TabState = require('../../src/common/tab-state');
 
-describe('TabState', function () {
+describe('TabState', function() {
   var states = TabState.states;
 
   var state;
   var onChange;
 
-  beforeEach(function () {
+  beforeEach(function() {
     onChange = sinon.spy();
-    state = new TabState({
-      1: {state: states.ACTIVE},
-    }, onChange);
+    state = new TabState(
+      {
+        1: { state: states.ACTIVE },
+      },
+      onChange
+    );
   });
 
-  it('can be initialized without any default state', function () {
-    assert.doesNotThrow(function () {
+  it('can be initialized without any default state', function() {
+    assert.doesNotThrow(function() {
       state = new TabState(null, onChange);
       state.isTabActive(1);
     });
   });
 
-  it('can be initialized without an onchange callback', function () {
-    assert.doesNotThrow(function () {
+  it('can be initialized without an onchange callback', function() {
+    assert.doesNotThrow(function() {
       state = new TabState();
       state.isTabActive(1);
     });
   });
 
-  describe('.load', function () {
-    it('replaces the current tab states with a new object', function () {
-      state.load({2: {state: states.INACTIVE}});
+  describe('.load', function() {
+    it('replaces the current tab states with a new object', function() {
+      state.load({ 2: { state: states.INACTIVE } });
       assert.equal(state.isTabActive(1), false);
       assert.equal(state.isTabInactive(2), true);
     });
   });
 
-  describe('.activateTab', function () {
-    it('sets the state for the tab id provided', function () {
+  describe('.activateTab', function() {
+    it('sets the state for the tab id provided', function() {
       state.activateTab(2);
       assert.equal(state.isTabActive(2), true);
     });
 
-    it('triggers an onchange handler', function () {
+    it('triggers an onchange handler', function() {
       state.activateTab(2);
-      assert.calledWith(onChange, 2, sinon.match({state: states.ACTIVE}));
+      assert.calledWith(onChange, 2, sinon.match({ state: states.ACTIVE }));
     });
   });
 
-  describe('.deactivateTab', function () {
-    it('sets the state for the tab id provided', function () {
+  describe('.deactivateTab', function() {
+    it('sets the state for the tab id provided', function() {
       state.deactivateTab(2);
       assert.equal(state.isTabInactive(2), true);
     });
 
-    it('triggers an onchange handler', function () {
+    it('triggers an onchange handler', function() {
       state.deactivateTab(2);
-      assert.calledWith(onChange, 2, sinon.match({state: states.INACTIVE}));
+      assert.calledWith(onChange, 2, sinon.match({ state: states.INACTIVE }));
     });
   });
 
-  describe('.errorTab', function () {
-    it('sets the state for the tab id provided', function () {
+  describe('.errorTab', function() {
+    it('sets the state for the tab id provided', function() {
       state.errorTab(2);
       assert.equal(state.isTabErrored(2), true);
     });
 
-    it('triggers an onchange handler', function () {
+    it('triggers an onchange handler', function() {
       state.errorTab(2);
-      assert.calledWith(onChange, 2, sinon.match({state: states.ERRORED}));
+      assert.calledWith(onChange, 2, sinon.match({ state: states.ERRORED }));
     });
   });
 
-  describe('.clearTab', function () {
-    it('removes the state for the tab id provided', function () {
+  describe('.clearTab', function() {
+    it('removes the state for the tab id provided', function() {
       state.clearTab(1);
-      assert.equal(state.isTabActive(1), false, 'expected isTabActive to return false');
-      assert.equal(state.isTabInactive(1), true, 'expected isTabInactive to return true');
-      assert.equal(state.isTabErrored(1), false, 'expected isTabInactive to return false');
+      assert.equal(
+        state.isTabActive(1),
+        false,
+        'expected isTabActive to return false'
+      );
+      assert.equal(
+        state.isTabInactive(1),
+        true,
+        'expected isTabInactive to return true'
+      );
+      assert.equal(
+        state.isTabErrored(1),
+        false,
+        'expected isTabInactive to return false'
+      );
     });
 
-    it('triggers an onchange handler', function () {
+    it('triggers an onchange handler', function() {
       state.clearTab(1);
       assert.calledWith(onChange, 1, undefined);
     });
   });
 
-  describe('.isTabActive', function () {
-    it('returns true if the tab is active', function () {
+  describe('.isTabActive', function() {
+    it('returns true if the tab is active', function() {
       state.activateTab(1);
       assert.equal(state.isTabActive(1), true);
     });
   });
 
-  describe('.isTabInactive', function () {
-    it('returns true if the tab is inactive', function () {
+  describe('.isTabInactive', function() {
+    it('returns true if the tab is inactive', function() {
       state.deactivateTab(1);
       assert.equal(state.isTabInactive(1), true);
     });
   });
 
-  describe('.isTabErrored', function () {
-    it('returns true if the tab is errored', function () {
+  describe('.isTabErrored', function() {
+    it('returns true if the tab is errored', function() {
       state.errorTab(1, new Error('Some error'));
       assert.equal(state.isTabErrored(1), true);
     });
   });
 
-  describe('.setState', function () {
-    it('clears the error when not errored', function () {
+  describe('.setState', function() {
+    it('clears the error when not errored', function() {
       state.errorTab(1, new Error('Some error'));
       assert.ok(state.getState(1).error instanceof Error);
-      state.setState(1, {state: states.INACTIVE});
+      state.setState(1, { state: states.INACTIVE });
       assert.notOk(state.getState(1).error);
     });
   });
 
-  describe('.updateAnnotationCount', function () {
-    beforeEach(function () {
+  describe('.updateAnnotationCount', function() {
+    beforeEach(function() {
       sinon.stub(console, 'error');
     });
 
-    afterEach(function () {
+    afterEach(function() {
       console.error.restore();
     });
 
-    it('queries the service and sets the annotation count', function () {
-      var queryStub = sinon.stub().returns(Promise.resolve({total: 42}));
+    it('queries the service and sets the annotation count', function() {
+      var queryStub = sinon.stub().returns(Promise.resolve({ total: 42 }));
       var TabState = proxyquire('../../src/common/tab-state', {
         './uri-info': {
           query: queryStub,
         },
       });
-      var tabState = new TabState({1: {state: states.ACTIVE}});
-      return tabState.updateAnnotationCount(1, 'foobar.com')
-        .then(function () {
-          assert.called(queryStub);
-          assert.equal(tabState.getState(1).annotationCount, 42);
-        });
+      var tabState = new TabState({ 1: { state: states.ACTIVE } });
+      return tabState.updateAnnotationCount(1, 'foobar.com').then(function() {
+        assert.called(queryStub);
+        assert.equal(tabState.getState(1).annotationCount, 42);
+      });
     });
 
-    it('resets the count if an error occurred', function () {
+    it('resets the count if an error occurred', function() {
       var queryStub = sinon.stub().returns(Promise.reject(new Error('err')));
       var TabState = proxyquire('../../src/common/tab-state', {
         './uri-info': {
           query: queryStub,
         },
       });
-      var tabState = new TabState({1: {
-        state: states.ACTIVE,
-        annotationCount: 42,
-      }});
-      return tabState.updateAnnotationCount(1, 'foobar.com')
-        .then(function () {
-          assert.called(queryStub);
-          assert.called(console.error);
-          assert.equal(tabState.getState(1).annotationCount, 0);
-        });
+      var tabState = new TabState({
+        1: {
+          state: states.ACTIVE,
+          annotationCount: 42,
+        },
+      });
+      return tabState.updateAnnotationCount(1, 'foobar.com').then(function() {
+        assert.called(queryStub);
+        assert.called(console.error);
+        assert.equal(tabState.getState(1).annotationCount, 0);
+      });
     });
   });
 });

--- a/tests/common/tab-store-test.js
+++ b/tests/common/tab-store-test.js
@@ -1,13 +1,15 @@
 'use strict';
 
-describe('TabStore', function () {
+describe('TabStore', function() {
   var TabStore = require('../../src/common/tab-store');
   var store;
   var fakeLocalStorage;
 
-  beforeEach(function () {
+  beforeEach(function() {
     fakeLocalStorage = {
-      getItem: sinon.spy(function (key) { return this.data[key]; }),
+      getItem: sinon.spy(function(key) {
+        return this.data[key];
+      }),
       setItem: sinon.spy(),
       removeItem: sinon.spy(),
       data: {},
@@ -15,26 +17,26 @@ describe('TabStore', function () {
     store = new TabStore(fakeLocalStorage);
   });
 
-  describe('.get', function () {
-    beforeEach(function () {
+  describe('.get', function() {
+    beforeEach(function() {
       fakeLocalStorage.data.state = JSON.stringify({
-        1: {state: 'active'},
+        1: { state: 'active' },
       });
       store.reload();
     });
 
-    it('retrieves a key from the cache', function () {
+    it('retrieves a key from the cache', function() {
       var value = store.get(1);
       assert.equal(value.state, 'active');
     });
 
-    it('raises an error if the key cannot be found', function () {
-      assert.throws(function () {
+    it('raises an error if the key cannot be found', function() {
+      assert.throws(function() {
         store.get(100);
       });
     });
 
-    it('converts state-string keys to objects', function () {
+    it('converts state-string keys to objects', function() {
       fakeLocalStorage.data.state = JSON.stringify({
         1: 'active',
       });
@@ -43,8 +45,8 @@ describe('TabStore', function () {
     });
   });
 
-  describe('.set', function () {
-    it('inserts a JSON string into the store for the tab id', function () {
+  describe('.set', function() {
+    it('inserts a JSON string into the store for the tab id', function() {
       var expected = JSON.stringify({
         1: { state: 'active' },
       });
@@ -52,19 +54,19 @@ describe('TabStore', function () {
       assert.calledWith(fakeLocalStorage.setItem, 'state', expected);
     });
 
-    it('adds new properties to the serialized object with each new call', function () {
+    it('adds new properties to the serialized object with each new call', function() {
       var expected = JSON.stringify({
         1: { state: 'active' },
-        2: { state: 'inactive'},
+        2: { state: 'inactive' },
       });
       store.set(1, { state: 'active' });
       store.set(2, { state: 'inactive' });
       assert.calledWith(fakeLocalStorage.setItem, 'state', expected);
     });
 
-    it('overrides existing properties on the serialized object', function () {
+    it('overrides existing properties on the serialized object', function() {
       var expected = JSON.stringify({
-        1: {state: 'inactive'},
+        1: { state: 'inactive' },
       });
       store.set(1, { state: 'active' });
       store.set(1, { state: 'inactive' });
@@ -72,27 +74,27 @@ describe('TabStore', function () {
     });
   });
 
-  describe('.unset', function () {
-    beforeEach(function () {
-      fakeLocalStorage.data.state = JSON.stringify({1: 'active'});
+  describe('.unset', function() {
+    beforeEach(function() {
+      fakeLocalStorage.data.state = JSON.stringify({ 1: 'active' });
       store.reload();
     });
 
-    it('removes a property from the serialized object', function () {
+    it('removes a property from the serialized object', function() {
       store.unset(1);
       assert.calledWith(fakeLocalStorage.setItem, 'state', '{}');
     });
   });
 
-  describe('.all', function () {
-    beforeEach(function () {
-      fakeLocalStorage.data.state = JSON.stringify({1: { state: 'active' }});
+  describe('.all', function() {
+    beforeEach(function() {
+      fakeLocalStorage.data.state = JSON.stringify({ 1: { state: 'active' } });
       store.reload();
     });
 
-    it('returns all items as an Object', function () {
+    it('returns all items as an Object', function() {
       var all = store.all();
-      assert.deepEqual(all, {1: { state: 'active' }});
+      assert.deepEqual(all, { 1: { state: 'active' } });
     });
   });
 });

--- a/tests/common/uri-info-test.js
+++ b/tests/common/uri-info-test.js
@@ -6,10 +6,10 @@ var unroll = require('../util').unroll;
 var uriInfo = require('../../src/common/uri-info');
 var settings = require('../settings.json');
 
-describe('UriInfo.query', function () {
+describe('UriInfo.query', function() {
   var badgeURL = settings.apiUrl + '/badge';
 
-  beforeEach(function () {
+  beforeEach(function() {
     sinon.stub(window, 'fetch').returns(
       Promise.resolve(
         new window.Response('{"total": 1}', {
@@ -22,47 +22,54 @@ describe('UriInfo.query', function () {
     sinon.stub(console, 'error');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     window.fetch.restore();
     console.error.restore();
   });
 
-  it('sends the correct XMLHttpRequest', function () {
-    return uriInfo.query('tabUrl').then(function () {
+  it('sends the correct XMLHttpRequest', function() {
+    return uriInfo.query('tabUrl').then(function() {
       assert.equal(fetch.callCount, 1);
-      assert.deepEqual(
-        fetch.lastCall.args,
-        [badgeURL + '?uri=tabUrl', {credentials: 'include'}]);
+      assert.deepEqual(fetch.lastCall.args, [
+        badgeURL + '?uri=tabUrl',
+        { credentials: 'include' },
+      ]);
     });
   });
 
-  it('urlencodes the URL appropriately', function () {
-    return toResult(uriInfo.query('http://foo.com?bar=baz qüx'))
-      .then(function () {
+  it('urlencodes the URL appropriately', function() {
+    return toResult(uriInfo.query('http://foo.com?bar=baz qüx')).then(
+      function() {
         assert.equal(fetch.callCount, 1);
         assert.equal(
-        fetch.lastCall.args[0],
-        badgeURL + '?uri=http%3A%2F%2Ffoo.com%3Fbar%3Dbaz+q%C3%BCx');
-      });
+          fetch.lastCall.args[0],
+          badgeURL + '?uri=http%3A%2F%2Ffoo.com%3Fbar%3Dbaz+q%C3%BCx'
+        );
+      }
+    );
   });
 
   var INVALID_RESPONSE_FIXTURES = [
-    {status: 200, headers: {}, body: 'this is not valid json'},
-    {status: 200, headers: {}, body: '{"total": "not a valid number"}'},
-    {status: 200, headers: {}, body: '{"rows": []}'},
+    { status: 200, headers: {}, body: 'this is not valid json' },
+    { status: 200, headers: {}, body: '{"total": "not a valid number"}' },
+    { status: 200, headers: {}, body: '{"rows": []}' },
   ];
 
-  unroll('returns an error if the server\'s JSON is invalid', function (response) {
-    fetch.returns(
-      Promise.resolve(
-        new window.Response(
-          response.body,
-          {status: response.status, headers: response.headers}
+  unroll(
+    "returns an error if the server's JSON is invalid",
+    function(response) {
+      fetch.returns(
+        Promise.resolve(
+          new window.Response(response.body, {
+            status: response.status,
+            headers: response.headers,
+          })
         )
-      )
-    );
-    return toResult(uriInfo.query('tabUrl')).then(function (result) {
-      assert.ok(result.error);
-    });
-  }, INVALID_RESPONSE_FIXTURES);
+      );
+      return toResult(uriInfo.query('tabUrl')).then(function(result) {
+        assert.ok(result.error);
+      });
+    },
+    INVALID_RESPONSE_FIXTURES
+  );
 });

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -2,20 +2,12 @@
 
 module.exports = function(config) {
   config.set({
-
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: './',
 
-
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: [
-      'browserify',
-      'mocha',
-      'chai',
-      'sinon',
-    ],
-
+    frameworks: ['browserify', 'mocha', 'chai', 'sinon'],
 
     // list of files / patterns to load in the browser
     files: [
@@ -29,8 +21,7 @@ module.exports = function(config) {
     ],
 
     // list of files to exclude
-    exclude: [
-    ],
+    exclude: [],
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
@@ -64,28 +55,22 @@ module.exports = function(config) {
     // for more helpful rendering of test failures
     reporters: ['mocha'],
 
-
     // web server port
     port: 9877,
 
-
     // enable / disable colors in the output (reporters and logs)
     colors: true,
-
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
     logLevel: config.LOG_INFO,
 
-
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: true,
-
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['PhantomJS'],
-
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/tests/promise-util.js
+++ b/tests/promise-util.js
@@ -8,11 +8,13 @@
  * as expected in tests.
  */
 function toResult(promise) {
-  return promise.then(function (result) {
-    return { result: result };
-  }).catch(function (err) {
-    return { error: err };
-  });
+  return promise
+    .then(function(result) {
+      return { result: result };
+    })
+    .catch(function(err) {
+      return { error: err };
+    });
 }
 
 module.exports = {

--- a/tests/util.js
+++ b/tests/util.js
@@ -30,18 +30,20 @@
  * @param {Array<T>} fixtures - Array of fixture objects.
  */
 function unroll(description, testFn, fixtures) {
-  fixtures.forEach(function (fixture) {
-    var caseDescription = Object.keys(fixture).reduce(function (desc, key) {
+  fixtures.forEach(function(fixture) {
+    var caseDescription = Object.keys(fixture).reduce(function(desc, key) {
       return desc.replace('#' + key, String(fixture[key]));
     }, description);
-    it(caseDescription, function (done) {
+    it(caseDescription, function(done) {
       if (testFn.length === 1) {
         // Test case does not accept a 'done' callback argument, so we either
         // call done() immediately if it returns a non-Promiselike object
         // or when the Promise resolves otherwise
         var result = testFn(fixture);
         if (typeof result === 'object' && result.then) {
-          result.then(function () { done(); }, done);
+          result.then(function() {
+            done();
+          }, done);
         } else {
           done();
         }


### PR DESCRIPTION
This PR follows the [recent change](https://github.com/hypothesis/client/pull/924) to the hypothesis/client project to enable automated code formatting using Prettier.

- Add `make format` and `make checkformatting` commands
- Disable indendation checks in ESLint that are obsoleted by Prettier
- Check formatting during Travis builds
- The last commit runs Prettier over the codebase to reformat it