### PR TITLE
Support direct links to groups

### DIFF
--- a/src/common/direct-link-query.js
+++ b/src/common/direct-link-query.js
@@ -38,7 +38,9 @@ function directLinkQuery(url) {
     return { query };
   }
 
-  var groupMatch = url.match(/#annotations:group:(.*)$/);
+  // Group IDs (and other "pubids" in h) are a subset of ASCII letters and
+  // digits.
+  var groupMatch = url.match(/#annotations:group:([A-Za-z0-9]+)$/);
   if (groupMatch) {
     return { group: groupMatch[1] };
   }

--- a/src/common/direct-link-query.js
+++ b/src/common/direct-link-query.js
@@ -1,30 +1,46 @@
 'use strict';
 
 /**
+ * Subset of the client configuration which causes the client to show a
+ * particular set of annotations automatically after it loads.
+ *
+ * See https://h-client.readthedocs.io/en/latest/publishers/config/#config-settings
+ *
  * @typedef {Object} Query
- * @property [string] id
- * @property [string] query
+ * @property {string} [annotations] - ID of the direct-linked annotation
+ * @property {string} [query] - Filter query from the sidebar
+ * @property {string} [group] - ID of the direct-linked group
  */
 
 /**
- * Extracts a direct-linked annotation ID or query from the fragment of a URL.
+ * Extracts the direct-linking query from the URL if any.
  *
- * @param {string} url - The URL which may contain a '#annotations:<ID>'
- *        or '#annotations:query:<query>' fragment.
+ * If present, the query causes the extension to activate automatically and
+ * show the matching set of annotations.
+ *
+ * @param {string} url -
+ *   The URL which may contain a '#annotations:' fragment specifying which
+ *   annotations to show.
  * @return {Query|null}
+ *   The direct link query translated into client configuration settings.
  */
 function directLinkQuery(url) {
   // Annotation IDs are url-safe-base64 identifiers
   // See https://tools.ietf.org/html/rfc4648#page-7
   var idMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);
   if (idMatch) {
-    return { id: idMatch[1] };
+    return { annotations: idMatch[1] };
   }
 
   var queryMatch = url.match(/#annotations:query:(.*)$/);
   if (queryMatch) {
     let query = decodeURIComponent(queryMatch[1]);
     return { query };
+  }
+
+  var groupMatch = url.match(/#annotations:group:(.*)$/);
+  if (groupMatch) {
+    return { group: groupMatch[1] };
   }
 
   return null;

--- a/src/common/hypothesis-chrome-extension.js
+++ b/src/common/hypothesis-chrome-extension.js
@@ -240,14 +240,12 @@ function HypothesisChromeExtension(dependencies) {
         sidebarAppUrl: chromeExtension.getURL('/client/app.html'),
       };
 
-      if (directLinkQuery) {
-        if (directLinkQuery.id) {
-          config.annotations = directLinkQuery.id;
-        }
-        if (directLinkQuery.query) {
-          config.query = directLinkQuery.query;
-        }
-      }
+      // Pass the direct-link query as configuration into the client.
+      //
+      // The reason we don't rely on just putting this into the URL and letting
+      // the client pick it up is to make direct-linking work in sites/apps
+      // that modify the URL fragment as they load. See commit 3143ca27e05d.
+      Object.assign(config, directLinkQuery);
 
       return sidebar
         .injectIntoTab(tab, config)

--- a/tests/common/direct-link-query-test.js
+++ b/tests/common/direct-link-query-test.js
@@ -8,11 +8,18 @@ describe('common.direct-link-query', () => {
     assert.equal(directLinkQuery(url), null);
   });
 
-  it('returns the ID if the URL contains a #annotations:<ID> fragment', () => {
+  it('returns the annotation ID if the URL contains a #annotations:<ID> fragment', () => {
     var url = 'https://example.com/#annotations:1234';
     assert.deepEqual(directLinkQuery(url), {
       annotations: '1234',
     });
+  });
+
+  it('does not return annotation ID if it is invalid', () => {
+    // "invalid" here refers only to the character set, not whether the annotation
+    // actually exists.
+    var url = 'https://example.com/#annotations:[foo]';
+    assert.equal(directLinkQuery(url), null);
   });
 
   it('returns the query if the URL contains a #annotations:query:<query> fragment', () => {
@@ -22,10 +29,17 @@ describe('common.direct-link-query', () => {
     });
   });
 
-  it('returns the group if the URL contains a #annotations:group:<id> fragment', () => {
+  it('returns the group ID if the URL contains a #annotations:group:<ID> fragment', () => {
     var url = 'https://example.com/#annotations:group:123';
     assert.deepEqual(directLinkQuery(url), {
       group: '123',
     });
+  });
+
+  it('does not return group ID if it is invalid', () => {
+    // "invalid" here refers only to the character set, not whether the group
+    // actually exists.
+    var url = 'https://example.com/#annotations:group:%%%';
+    assert.deepEqual(directLinkQuery(url), null);
   });
 });

--- a/tests/common/direct-link-query-test.js
+++ b/tests/common/direct-link-query-test.js
@@ -11,14 +11,21 @@ describe('common.direct-link-query', () => {
   it('returns the ID if the URL contains a #annotations:<ID> fragment', () => {
     var url = 'https://example.com/#annotations:1234';
     assert.deepEqual(directLinkQuery(url), {
-      id: '1234',
+      annotations: '1234',
     });
   });
 
-  it('returns the query if the URL contains a #annotations:<query> fragment', () => {
+  it('returns the query if the URL contains a #annotations:query:<query> fragment', () => {
     var url = 'https://example.com/#annotations:query:user%3Ajsmith';
     assert.deepEqual(directLinkQuery(url), {
       query: 'user:jsmith',
+    });
+  });
+
+  it('returns the group if the URL contains a #annotations:group:<id> fragment', () => {
+    var url = 'https://example.com/#annotations:group:123';
+    assert.deepEqual(directLinkQuery(url), {
+      group: '123',
     });
   });
 });

--- a/tests/common/hypothesis-chrome-extension-test.js
+++ b/tests/common/hypothesis-chrome-extension-test.js
@@ -284,7 +284,11 @@ describe('HypothesisChromeExtension', function() {
         assert.equal(tabState[tab.id].state, TabState.states.ACTIVE);
       });
 
-      ['#annotations:456', '#annotations:query:blah'].forEach(fragment => {
+      [
+        '#annotations:456',
+        '#annotations:query:blah',
+        '#annotations:group:123',
+      ].forEach(fragment => {
         it('injects the sidebar if a direct link is present', function() {
           var tab = createTab();
           tab.url += fragment;


### PR DESCRIPTION
Support the `#annotations:group:<ID>` syntax used to direct-link to
groups.

As part of this, refactor the code so that the knowledge about the
different kinds of direct-link query that can be used only exists in
one place, `direct-link-query.js`, which is responsible for mapping the
query to additional client configuration.

Also add some comments about why the browser extension has to deal with
direct-links itself in the first place.

----

To make it harder to overlook this in future if we change the direct linking syntax again, we could rework the overall flow as follows:

1. User navigates to $BOUNCER_URL/$QUERY
2. Bouncer detects the extension and sends it a message indicating the URL to open in the current tab and additional client configuration to pass to the client
3. The browser extension responds to this message by loading the provided URL and passing the given config to the client

This would avoid the browser extension needing to know the details of the direct-linking syntax.