### PR TITLE
Fix detection of whether a tab is using Chrome's PDF viewer

### DIFF
--- a/src/common/detect-content-type.js
+++ b/src/common/detect-content-type.js
@@ -22,12 +22,10 @@ function detectContentType(document_) {
     // instantiates the native PDF renderer.
     //
     // The selector below matches the <embed> tag in the top-level document. To
-    // see this document, open the inspector on a PDF viewer tab with
-    // Ctrl+Shift+I rather than right-clicking on the viewport and selecting the
-    // 'Inspect' option which will instead show the _inner_ document.
-    if (
-      document_.querySelector('embed[type="application/pdf"][name="plugin"]')
-    ) {
+    // see this document, open the developer tools from Chrome's menu rather
+    // than right-clicking on the viewport and selecting the 'Inspect' option
+    // which will instead show the _inner_ document.
+    if (document_.querySelector('embed[type="application/pdf"]')) {
       return { type: 'PDF' };
     }
     return null;

--- a/tests/common/detect-content-type-test.js
+++ b/tests/common/detect-content-type-test.js
@@ -19,7 +19,7 @@ describe('detectContentType()', function() {
   });
 
   it('returns "PDF" if Google Chrome PDF viewer is present', function() {
-    el.innerHTML = '<embed name="plugin" type="application/pdf"></embed>';
+    el.innerHTML = '<embed type="application/pdf"></embed>';
     assert.deepEqual(detectContentType(), { type: 'PDF' });
   });
 


### PR DESCRIPTION
Chrome recently made changes to how the native PDF viewer is loaded [1],
which slightly changes the HTML of the top-level document in tabs that
are using this viewer. Specifically, the `<embed>` element no longer has a
`name` attribute. This broke the browser extension's detection of
whether the current document is a PDF by checking whether Chrome is
using its native PDF viewer to show it [2].

Resolve the issue by adjusting the CSS selector slightly.

To test, verify that activating the extension on a PDF uses the bundled
PDF.js viewer both when the "MimeHandlerViewer in cross-process frame"
feature flag in Chrome is turned on (at chrome://flags) and when it is
turned off.

Fixes #212

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=659750

[2] nb. We use this method rather than relying only on the file
    extension because not all PDF URLs have a path with a `.pdf` suffix,
    and AFAIK there is no way to get the MIME type of an already-loaded
    document.