### PR TITLE
Remove reference to raven-js.bundle.js from background page manifest

### DIFF
--- a/src/chrome/manifest.json.mustache
+++ b/src/chrome/manifest.json.mustache
@@ -64,7 +64,6 @@
     {{/browserIsChrome}}
     "scripts": [
       "settings-data.js",
-      "client/build/scripts/raven.bundle.js",
       "extension.bundle.js"
     ]
   },


### PR DESCRIPTION
Remove a reference to a client script bundle from the background page.
The name of the bundle changed in the client to `sentry.bundle.js` and
now contains different packages.

The browser extension should not depend on the package structure of the
client, so simply remove this dependency from the background page. If
the background page wants to use Sentry, it should use its own copy of
the code.

I'm not entirely clear on why this dependency was added in the first
place. It was not explained in the commit
(a3a48770ae1fd5ed65e1fdbc0a974699e1c1e800) that added it.