### PR TITLE
Bump minimum Firefox version

### DIFF
--- a/src/chrome/manifest.json.mustache
+++ b/src/chrome/manifest.json.mustache
@@ -18,9 +18,7 @@
   {{#browserIsFirefox}}
   "applications": {
     "gecko": {
-      {{! Firefox v48 is required for
-          https://bugzilla.mozilla.org/show_bug.cgi?id=1210583 }}
-      "strict_min_version": "48.0"
+      "strict_min_version": "60.0"
     }
   },
   {{/browserIsFirefox}}


### PR DESCRIPTION
Firefox's extension validation service is producing many warnings
complaining about APIs that are unsupported in Firefox v48 [1]. Since the FF
extension doesn't have active users at the moment, there is no harm in
bumping the minimum version to the current Firefox ESR release (v60).

[1] See eg. https://addons.mozilla.org/en-US/developers/upload/5efc192fadf74767bfe9735e006e3f0d