### PR TITLE
Remove an obsolete class from config script tag

### DIFF
--- a/src/sidebar-app.html.mustache
+++ b/src/sidebar-app.html.mustache
@@ -10,10 +10,7 @@
   <body>
     <hypothesis-app></hypothesis-app>
 
-    {{! The `js-hypothesis-settings` class can be removed once the client is
-        updated to include https://github.com/hypothesis/client/pull/243
-    }}
-    <script class="js-hypothesis-config js-hypothesis-settings" type="application/json">
+    <script class="js-hypothesis-config" type="application/json">
     {{&settings}}
     </script>
 


### PR DESCRIPTION
The related client change was deployed a long time ago.