### PR TITLE
Convert background page to ES modules

### DIFF
--- a/src/background/.eslintrc
+++ b/src/background/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/src/background/browser-action.js
+++ b/src/background/browser-action.js
@@ -1,7 +1,5 @@
-'use strict';
-
-var settings = require('./settings');
-var TabState = require('./tab-state');
+import settings from './settings';
+import TabState from './tab-state';
 
 // Cache the tab state constants.
 var states = TabState.states;
@@ -43,7 +41,7 @@ function _(str) {
  * a tab (whether the extension is active, annotation count) to
  * the badge state.
  */
-function BrowserAction(chromeBrowserAction) {
+export default function BrowserAction(chromeBrowserAction) {
   var buildType = settings.buildType;
 
   /**
@@ -106,5 +104,3 @@ function BrowserAction(chromeBrowserAction) {
 }
 
 BrowserAction.icons = icons;
-
-module.exports = BrowserAction;

--- a/src/background/browser-name.js
+++ b/src/background/browser-name.js
@@ -1,16 +1,12 @@
-'use strict';
-
 /**
  * Returns the name of the current browser.
  *
  * @return {'chrome'|'firefox'}
  */
-function browserName() {
+export default function browserName() {
   if (window.browser) {
     return 'firefox';
   } else {
     return 'chrome';
   }
 }
-
-module.exports = browserName;

--- a/src/background/detect-content-type.js
+++ b/src/background/detect-content-type.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Returns the type of content in the current document,
  * currently either 'PDF' or 'HTML'.
@@ -12,7 +10,7 @@
  * of content in embedded viewers where that differs from the tab's
  * main URL.
  */
-function detectContentType(document_) {
+export default function detectContentType(document_) {
   document_ = document_ || document;
 
   function detectChromePDFViewer() {
@@ -57,5 +55,3 @@ function detectContentType(document_) {
 
   return { type: 'HTML' };
 }
-
-module.exports = detectContentType;

--- a/src/background/direct-link-query.js
+++ b/src/background/direct-link-query.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Subset of the client configuration which causes the client to show a
  * particular set of annotations automatically after it loads.
@@ -24,7 +22,7 @@
  * @return {Query|null}
  *   The direct link query translated into client configuration settings.
  */
-function directLinkQuery(url) {
+export default function directLinkQuery(url) {
   // Annotation IDs are url-safe-base64 identifiers
   // See https://tools.ietf.org/html/rfc4648#page-7
   var idMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);
@@ -47,5 +45,3 @@ function directLinkQuery(url) {
 
   return null;
 }
-
-module.exports = directLinkQuery;

--- a/src/background/errors.js
+++ b/src/background/errors.js
@@ -1,41 +1,45 @@
-'use strict';
+import * as raven from './raven';
 
-var raven = require('./raven');
-
-function ExtensionError(message) {
+export function ExtensionError(message) {
   Error.apply(this, arguments);
   this.message = message;
 }
+
 ExtensionError.prototype = Object.create(Error.prototype);
 
-function LocalFileError(message) {
+export function LocalFileError(message) {
   Error.apply(this, arguments);
   this.message = message;
 }
+
 LocalFileError.prototype = Object.create(ExtensionError.prototype);
 
-function NoFileAccessError(message) {
+export function NoFileAccessError(message) {
   Error.apply(this, arguments);
   this.message = message;
 }
+
 NoFileAccessError.prototype = Object.create(ExtensionError.prototype);
 
-function RestrictedProtocolError(message) {
+export function RestrictedProtocolError(message) {
   Error.apply(this, arguments);
   this.message = message;
 }
+
 RestrictedProtocolError.prototype = Object.create(ExtensionError.prototype);
 
-function BlockedSiteError(message) {
+export function BlockedSiteError(message) {
   Error.apply(this, arguments);
   this.message = message;
 }
+
 BlockedSiteError.prototype = Object.create(ExtensionError.prototype);
 
-function AlreadyInjectedError(message) {
+export function AlreadyInjectedError(message) {
   Error.apply(this, arguments);
   this.message = message;
 }
+
 AlreadyInjectedError.prototype = Object.create(ExtensionError.prototype);
 
 /**
@@ -60,7 +64,7 @@ var IGNORED_ERRORS = [
  *
  * @param {{message: string}} err - The Error-like object
  */
-function shouldIgnoreInjectionError(err) {
+export function shouldIgnoreInjectionError(err) {
   if (
     IGNORED_ERRORS.some(function(pattern) {
       return err.message.match(pattern);
@@ -85,20 +89,9 @@ function shouldIgnoreInjectionError(err) {
  * @param {string} when - Describes the context in which the error occurred.
  * @param {Object} context - Additional context for the error.
  */
-function report(error, when, context) {
+export function report(error, when, context) {
   console.error(when, error);
   if (!isKnownError(error)) {
     raven.report(error, when, context);
   }
 }
-
-module.exports = {
-  ExtensionError: ExtensionError,
-  AlreadyInjectedError: AlreadyInjectedError,
-  LocalFileError: LocalFileError,
-  NoFileAccessError: NoFileAccessError,
-  RestrictedProtocolError: RestrictedProtocolError,
-  BlockedSiteError: BlockedSiteError,
-  report: report,
-  shouldIgnoreInjectionError: shouldIgnoreInjectionError,
-};

--- a/src/background/help-page.js
+++ b/src/background/help-page.js
@@ -1,7 +1,5 @@
-'use strict';
-
-var browserName = require('./browser-name');
-var errors = require('./errors');
+import browserName from './browser-name';
+import * as errors from './errors';
 
 /* A controller for displaying help pages. These are bound to extension
  * specific errors (found in errors.js) but can also be triggered manually.
@@ -11,7 +9,7 @@ var errors = require('./errors');
  *   to the file inside the chrome extension. See:
  *   https://developer.chrome.com/extensions/extension#method-getURL
  */
-function HelpPage(chromeTabs, extensionURL, browserName_) {
+export default function HelpPage(chromeTabs, extensionURL, browserName_) {
   browserName_ = browserName_ || browserName;
 
   /* Accepts an instance of errors.ExtensionError and displays an appropriate
@@ -71,5 +69,3 @@ function HelpPage(chromeTabs, extensionURL, browserName_) {
     chromeTabs.create(tabOpts);
   }
 }
-
-module.exports = HelpPage;

--- a/src/background/hypothesis-chrome-extension.js
+++ b/src/background/hypothesis-chrome-extension.js
@@ -1,13 +1,11 @@
-'use strict';
-
-var BrowserAction = require('./browser-action');
-var HelpPage = require('./help-page');
-var SidebarInjector = require('./sidebar-injector');
-var TabState = require('./tab-state');
-var TabStore = require('./tab-store');
-var directLinkQuery = require('./direct-link-query');
-var errors = require('./errors');
-var settings = require('./settings');
+import BrowserAction from './browser-action';
+import directLinkQuery from './direct-link-query';
+import * as errors from './errors';
+import HelpPage from './help-page';
+import settings from './settings';
+import SidebarInjector from './sidebar-injector';
+import TabState from './tab-state';
+import TabStore from './tab-store';
 
 var TAB_STATUS_LOADING = 'loading';
 var TAB_STATUS_COMPLETE = 'complete';
@@ -39,7 +37,7 @@ var TAB_STATUS_COMPLETE = 'complete';
  *   extensionURL: chrome.extension.getURL.
  *   isAllowedFileSchemeAccess: chrome.extension.isAllowedFileSchemeAccess.
  */
-function HypothesisChromeExtension(dependencies) {
+export default function HypothesisChromeExtension(dependencies) {
   var chromeTabs = dependencies.chromeTabs;
   var chromeExtension = dependencies.chromeExtension;
   var chromeStorage = dependencies.chromeStorage;
@@ -298,5 +296,3 @@ function HypothesisChromeExtension(dependencies) {
     );
   }
 }
-
-module.exports = HypothesisChromeExtension;

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,10 +1,8 @@
-'use strict';
-
-var raven = require('./raven');
+import * as raven from './raven';
 
 if (window.EXTENSION_CONFIG.raven) {
   raven.init(window.EXTENSION_CONFIG.raven);
 }
 
-require('./hypothesis-chrome-extension');
-require('./install');
+import './hypothesis-chrome-extension';
+import './install';

--- a/src/background/install.js
+++ b/src/background/install.js
@@ -1,10 +1,8 @@
-'use strict';
-
-var HypothesisChromeExtension = require('./hypothesis-chrome-extension');
+import HypothesisChromeExtension from './hypothesis-chrome-extension';
 
 var browserExtension;
 
-function init() {
+export function init() {
   browserExtension = new HypothesisChromeExtension({
     chromeExtension: chrome.extension,
     chromeTabs: chrome.tabs,
@@ -70,5 +68,3 @@ function onInstalled(installDetails) {
 function onUpdateAvailable() {
   chrome.runtime.reload();
 }
-
-module.exports = { init };

--- a/src/background/raven.js
+++ b/src/background/raven.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * This module configures Raven for reporting crashes
  * to Sentry.
@@ -8,7 +6,7 @@
  * version to be provided via the app's settings object.
  */
 
-var Raven = require('raven-js');
+import Raven from 'raven-js';
 
 /**
  * Returns the input URL if it is an HTTP URL or the filename part of the URL
@@ -63,7 +61,7 @@ function translateSourceURLs(data) {
   return data;
 }
 
-function init(config) {
+export function init(config) {
   Raven.config(config.dsn, {
     release: config.release,
     dataCallback: translateSourceURLs,
@@ -81,7 +79,7 @@ function init(config) {
  *                             information which may be useful when
  *                             investigating the error.
  */
-function report(error, when, context) {
+export function report(error, when, context) {
   if (!(error instanceof Error)) {
     // If the passed object is not an Error, raven-js
     // will serialize it using toString() which produces unhelpful results
@@ -120,8 +118,3 @@ function installUnhandledPromiseErrorHandler() {
     }
   });
 }
-
-module.exports = {
-  init: init,
-  report: report,
-};

--- a/src/background/settings.js
+++ b/src/background/settings.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Validate and normalize the given settings data.
  *
@@ -16,4 +14,4 @@ function normalizeSettings(settings) {
 /**
  * Returns the configuration object for the Chrome extension
  */
-module.exports = normalizeSettings(window.EXTENSION_CONFIG);
+export default normalizeSettings(window.EXTENSION_CONFIG);

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -1,10 +1,8 @@
-'use strict';
+import * as queryString from 'query-string';
 
-var queryString = require('query-string');
-
-var detectContentType = require('./detect-content-type');
-var errors = require('./errors');
-var util = require('./util');
+import detectContentType from './detect-content-type';
+import * as errors from './errors';
+import * as util from './util';
 
 var CONTENT_TYPE_HTML = 'HTML';
 var CONTENT_TYPE_PDF = 'PDF';
@@ -62,7 +60,7 @@ function extractContentScriptResult(result) {
  *   extensionURL: A function that receives a path and returns an absolute
  *   url. See: https://developer.chrome.com/extensions/extension#method-getURL
  */
-function SidebarInjector(chromeTabs, dependencies) {
+export default function SidebarInjector(chromeTabs, dependencies) {
   dependencies = dependencies || {};
 
   var isAllowedFileSchemeAccess = dependencies.isAllowedFileSchemeAccess;
@@ -350,5 +348,3 @@ function SidebarInjector(chromeTabs, dependencies) {
     return executeScriptFn(tabId, { code: configCode });
   }
 }
-
-module.exports = SidebarInjector;

--- a/src/background/tab-state.js
+++ b/src/background/tab-state.js
@@ -1,8 +1,6 @@
-'use strict';
+import isShallowEqual from 'is-equal-shallow';
 
-var isShallowEqual = require('is-equal-shallow');
-
-var uriInfo = require('./uri-info');
+import * as uriInfo from './uri-info';
 
 var states = {
   ACTIVE: 'active',
@@ -46,7 +44,7 @@ var DEFAULT_STATE = {
  *   the default state for a tab.
  * onchange     - A function that recieves onchange(tabId, current).
  */
-function TabState(initialState, onchange) {
+export default function TabState(initialState, onchange) {
   var self = this;
   var currentState;
 
@@ -170,5 +168,3 @@ function TabState(initialState, onchange) {
 }
 
 TabState.states = states;
-
-module.exports = TabState;

--- a/src/background/tab-store.js
+++ b/src/background/tab-store.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /** TabStore is used to persist the state of H browser tabs when
  * the extension is re-installed or updated.
  *
@@ -7,7 +5,7 @@
  * for that to work however the storage key would need to be changed.
  * The tab ID is currently used but this is valid only for a browser session.
  */
-function TabStore(storage) {
+export default function TabStore(storage) {
   var key = 'state';
   var local;
 
@@ -60,5 +58,3 @@ function TabStore(storage) {
 
   this.reload();
 }
-
-module.exports = TabStore;

--- a/src/background/uri-info.js
+++ b/src/background/uri-info.js
@@ -1,6 +1,4 @@
-'use strict';
-
-var settings = require('./settings');
+import settings from './settings';
 
 /** encodeUriQuery encodes a string for use in a query parameter */
 function encodeUriQuery(val) {
@@ -11,7 +9,7 @@ function encodeUriQuery(val) {
  * Queries the Hypothesis service that provides
  * statistics about the annotations for a given URL.
  */
-function query(uri) {
+export function query(uri) {
   return fetch(settings.apiUrl + '/badge?uri=' + encodeUriQuery(uri), {
     credentials: 'include',
   })
@@ -25,7 +23,3 @@ function query(uri) {
       return data;
     });
 }
-
-module.exports = {
-  query: query,
-};

--- a/src/background/util.js
+++ b/src/background/util.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function getLastError() {
   if (typeof chrome !== 'undefined' && chrome.extension) {
     return chrome.extension.lastError;
@@ -24,7 +22,7 @@ function getLastError() {
  *           is invoked, the promise is rejected if chrome.extension.lastError
  *           is set or resolved with the first argument to the callback otherwise.
  */
-function promisify(fn) {
+export function promisify(fn) {
   return function() {
     var args = [].slice.call(arguments);
     var result = new Promise(function(resolve, reject) {
@@ -43,7 +41,3 @@ function promisify(fn) {
     return result;
   };
 }
-
-module.exports = {
-  promisify: promisify,
-};

--- a/tests/background/.eslintrc
+++ b/tests/background/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/tests/background/browser-action-test.js
+++ b/tests/background/browser-action-test.js
@@ -162,7 +162,9 @@ describe('BrowserAction', function() {
         buildType: 'staging',
       };
       $imports.$mock({
-        './settings': fakeSettings,
+        './settings': {
+          default: fakeSettings,
+        },
       });
       action = new BrowserAction(fakeChromeBrowserAction);
     });

--- a/tests/background/browser-action-test.js
+++ b/tests/background/browser-action-test.js
@@ -1,5 +1,4 @@
-import BrowserAction from '../../src/background/browser-action';
-import { $imports } from '../../src/background/browser-action';
+import BrowserAction, { $imports } from '../../src/background/browser-action';
 import TabState from '../../src/background/tab-state';
 
 describe('BrowserAction', function() {

--- a/tests/background/browser-action-test.js
+++ b/tests/background/browser-action-test.js
@@ -1,8 +1,6 @@
-'use strict';
-
-var BrowserAction = require('../../src/background/browser-action');
-var { $imports } = require('../../src/background/browser-action');
-var TabState = require('../../src/background/tab-state');
+import BrowserAction from '../../src/background/browser-action';
+import { $imports } from '../../src/background/browser-action';
+import TabState from '../../src/background/tab-state';
 
 describe('BrowserAction', function() {
   var action;

--- a/tests/background/browser-action-test.js
+++ b/tests/background/browser-action-test.js
@@ -1,8 +1,8 @@
 'use strict';
+var BrowserAction = require('../../src/background/browser-action');
+var TabState = require('../../src/background/tab-state');
 
 describe('BrowserAction', function() {
-  var BrowserAction = require('../../src/background/browser-action');
-  var TabState = require('../../src/background/tab-state');
   var action;
   var fakeChromeBrowserAction;
 

--- a/tests/background/browser-action-test.js
+++ b/tests/background/browser-action-test.js
@@ -1,5 +1,7 @@
 'use strict';
+
 var BrowserAction = require('../../src/background/browser-action');
+var { $imports } = require('../../src/background/browser-action');
 var TabState = require('../../src/background/tab-state');
 
 describe('BrowserAction', function() {
@@ -161,14 +163,14 @@ describe('BrowserAction', function() {
       var fakeSettings = {
         buildType: 'staging',
       };
-      BrowserAction.$imports.$mock({
+      $imports.$mock({
         './settings': fakeSettings,
       });
       action = new BrowserAction(fakeChromeBrowserAction);
     });
 
     afterEach(() => {
-      BrowserAction.$imports.$restore();
+      $imports.$restore();
     });
 
     it('sets the text to STG when there are no annotations', function() {

--- a/tests/background/detect-content-type-test.js
+++ b/tests/background/detect-content-type-test.js
@@ -1,6 +1,4 @@
-'use strict';
-
-var detectContentType = require('../../src/background/detect-content-type');
+import detectContentType from '../../src/background/detect-content-type';
 
 describe('detectContentType()', function() {
   var el;

--- a/tests/background/direct-link-query-test.js
+++ b/tests/background/direct-link-query-test.js
@@ -1,6 +1,4 @@
-'use strict';
-
-var directLinkQuery = require('../../src/background/direct-link-query');
+import directLinkQuery from '../../src/background/direct-link-query';
 
 describe('common.direct-link-query', () => {
   it('returns `null` if the URL contains no #annotations fragment', () => {

--- a/tests/background/errors-test.js
+++ b/tests/background/errors-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const errors = require('../../src/background/errors');
+const { $imports } = require('../../src/background/errors');
 
 describe('errors', function() {
   var fakeRaven;
@@ -9,7 +10,7 @@ describe('errors', function() {
     fakeRaven = {
       report: sinon.stub(),
     };
-    errors.$imports.$mock({
+    $imports.$mock({
       './raven': fakeRaven,
     });
     sinon.stub(console, 'error');
@@ -17,7 +18,7 @@ describe('errors', function() {
 
   afterEach(function() {
     console.error.restore();
-    errors.$imports.$restore();
+    $imports.$restore();
   });
 
   describe('#shouldIgnoreInjectionError', function() {

--- a/tests/background/errors-test.js
+++ b/tests/background/errors-test.js
@@ -1,5 +1,4 @@
 import * as errors from '../../src/background/errors';
-import { $imports } from '../../src/background/errors';
 
 describe('errors', function() {
   var fakeRaven;
@@ -8,7 +7,7 @@ describe('errors', function() {
     fakeRaven = {
       report: sinon.stub(),
     };
-    $imports.$mock({
+    errors.$imports.$mock({
       './raven': fakeRaven,
     });
     sinon.stub(console, 'error');
@@ -16,7 +15,7 @@ describe('errors', function() {
 
   afterEach(function() {
     console.error.restore();
-    $imports.$restore();
+    errors.$imports.$restore();
   });
 
   describe('#shouldIgnoreInjectionError', function() {

--- a/tests/background/errors-test.js
+++ b/tests/background/errors-test.js
@@ -1,7 +1,5 @@
-'use strict';
-
-const errors = require('../../src/background/errors');
-const { $imports } = require('../../src/background/errors');
+import * as errors from '../../src/background/errors';
+import { $imports } from '../../src/background/errors';
 
 describe('errors', function() {
   var fakeRaven;

--- a/tests/background/help-page-test.js
+++ b/tests/background/help-page-test.js
@@ -1,7 +1,5 @@
-'use strict';
-
-var errors = require('../../src/background/errors');
-var HelpPage = require('../../src/background/help-page');
+import * as errors from '../../src/background/errors';
+import HelpPage from '../../src/background/help-page';
 
 describe('HelpPage', function() {
   var fakeBrowserName;

--- a/tests/background/help-page-test.js
+++ b/tests/background/help-page-test.js
@@ -1,8 +1,9 @@
 'use strict';
 
+var errors = require('../../src/background/errors');
+var HelpPage = require('../../src/background/help-page');
+
 describe('HelpPage', function() {
-  var errors = require('../../src/background/errors');
-  var HelpPage = require('../../src/background/help-page');
   var fakeBrowserName;
   var fakeChromeTabs;
   var fakeExtensionURL;

--- a/tests/background/hypothesis-chrome-extension-test.js
+++ b/tests/background/hypothesis-chrome-extension-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var HypothesisChromeExtension = require('../../src/background/hypothesis-chrome-extension');
+var { $imports } = require('../../src/background/hypothesis-chrome-extension');
 var { toResult } = require('../promise-util');
 
 var errors = require('../../src/background/errors');
@@ -122,7 +123,7 @@ describe('HypothesisChromeExtension', function() {
     FakeTabState.prototype = fakeTabState;
     FakeTabState.states = TabState.states;
 
-    HypothesisChromeExtension.$imports.$mock({
+    $imports.$mock({
       './tab-state': FakeTabState,
       './tab-store': createConstructor(fakeTabStore),
       './help-page': createConstructor(fakeHelpPage),
@@ -139,7 +140,7 @@ describe('HypothesisChromeExtension', function() {
 
   afterEach(function() {
     sandbox.restore();
-    HypothesisChromeExtension.$imports.$restore();
+    $imports.$restore();
   });
 
   describe('.install', function() {

--- a/tests/background/hypothesis-chrome-extension-test.js
+++ b/tests/background/hypothesis-chrome-extension-test.js
@@ -1,6 +1,7 @@
 import * as errors from '../../src/background/errors';
-import HypothesisChromeExtension from '../../src/background/hypothesis-chrome-extension';
-import { $imports } from '../../src/background/hypothesis-chrome-extension';
+import HypothesisChromeExtension, {
+  $imports,
+} from '../../src/background/hypothesis-chrome-extension';
 import TabState from '../../src/background/tab-state';
 import { toResult } from '../promise-util';
 

--- a/tests/background/hypothesis-chrome-extension-test.js
+++ b/tests/background/hypothesis-chrome-extension-test.js
@@ -1,11 +1,8 @@
-'use strict';
-
-var HypothesisChromeExtension = require('../../src/background/hypothesis-chrome-extension');
-var { $imports } = require('../../src/background/hypothesis-chrome-extension');
-var { toResult } = require('../promise-util');
-
-var errors = require('../../src/background/errors');
-var TabState = require('../../src/background/tab-state');
+import * as errors from '../../src/background/errors';
+import HypothesisChromeExtension from '../../src/background/hypothesis-chrome-extension';
+import { $imports } from '../../src/background/hypothesis-chrome-extension';
+import TabState from '../../src/background/tab-state';
+import { toResult } from '../promise-util';
 
 // Creates a constructor function which takes no arguments
 // and has a given prototype.

--- a/tests/background/hypothesis-chrome-extension-test.js
+++ b/tests/background/hypothesis-chrome-extension-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var HypothesisChromeExtension = require('../../src/background/hypothesis-chrome-extension');
-var toResult = require('../promise-util').toResult;
+var { toResult } = require('../promise-util');
 
 var errors = require('../../src/background/errors');
 var TabState = require('../../src/background/tab-state');

--- a/tests/background/hypothesis-chrome-extension-test.js
+++ b/tests/background/hypothesis-chrome-extension-test.js
@@ -128,7 +128,9 @@ describe('HypothesisChromeExtension', function() {
       './sidebar-injector': createConstructor(fakeSidebarInjector),
       './errors': fakeErrors,
       './settings': {
-        serviceUrl: 'https://hypothes.is/',
+        default: {
+          serviceUrl: 'https://hypothes.is/',
+        },
       },
     });
 

--- a/tests/background/install-test.js
+++ b/tests/background/install-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var extension;
 
 function FakeHypothesisChromeExtension(deps) {

--- a/tests/background/sidebar-injector-test.js
+++ b/tests/background/sidebar-injector-test.js
@@ -1,8 +1,6 @@
-'use strict';
-
-var { toResult } = require('../promise-util');
-var errors = require('../../src/background/errors');
-var SidebarInjector = require('../../src/background/sidebar-injector');
+import * as errors from '../../src/background/errors';
+import SidebarInjector from '../../src/background/sidebar-injector';
+import { toResult } from '../promise-util';
 
 // The root URL for the extension returned by the
 // extensionURL(path) fake

--- a/tests/background/sidebar-injector-test.js
+++ b/tests/background/sidebar-injector-test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var toResult = require('../promise-util').toResult;
+var { toResult } = require('../promise-util');
+var errors = require('../../src/background/errors');
+var SidebarInjector = require('../../src/background/sidebar-injector');
 
 // The root URL for the extension returned by the
 // extensionURL(path) fake
@@ -23,8 +25,6 @@ function createTestFrame() {
 }
 
 describe('SidebarInjector', function() {
-  var errors = require('../../src/background/errors');
-  var SidebarInjector = require('../../src/background/sidebar-injector');
   var injector;
   var fakeChromeTabs;
   var fakeFileAccess;

--- a/tests/background/tab-state-test.js
+++ b/tests/background/tab-state-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var TabState = require('../../src/background/tab-state');
+var { $imports } = require('../../src/background/tab-state');
 
 describe('TabState', function() {
   var states = TabState.states;
@@ -139,12 +140,12 @@ describe('TabState', function() {
 
     afterEach(function() {
       console.error.restore();
-      TabState.$imports.$restore();
+      $imports.$restore();
     });
 
     it('queries the service and sets the annotation count', function() {
       var queryStub = sinon.stub().returns(Promise.resolve({ total: 42 }));
-      TabState.$imports.$mock({
+      $imports.$mock({
         './uri-info': {
           query: queryStub,
         },
@@ -158,7 +159,7 @@ describe('TabState', function() {
 
     it('resets the count if an error occurred', function() {
       var queryStub = sinon.stub().returns(Promise.reject(new Error('err')));
-      TabState.$imports.$mock({
+      $imports.$mock({
         './uri-info': {
           query: queryStub,
         },

--- a/tests/background/tab-state-test.js
+++ b/tests/background/tab-state-test.js
@@ -1,7 +1,5 @@
-'use strict';
-
-var TabState = require('../../src/background/tab-state');
-var { $imports } = require('../../src/background/tab-state');
+import TabState from '../../src/background/tab-state';
+import { $imports } from '../../src/background/tab-state';
 
 describe('TabState', function() {
   var states = TabState.states;

--- a/tests/background/tab-state-test.js
+++ b/tests/background/tab-state-test.js
@@ -1,5 +1,4 @@
-import TabState from '../../src/background/tab-state';
-import { $imports } from '../../src/background/tab-state';
+import TabState, { $imports } from '../../src/background/tab-state';
 
 describe('TabState', function() {
   var states = TabState.states;

--- a/tests/background/tab-store-test.js
+++ b/tests/background/tab-store-test.js
@@ -1,7 +1,8 @@
 'use strict';
 
+var TabStore = require('../../src/background/tab-store');
+
 describe('TabStore', function() {
-  var TabStore = require('../../src/background/tab-store');
   var store;
   var fakeLocalStorage;
 

--- a/tests/background/tab-store-test.js
+++ b/tests/background/tab-store-test.js
@@ -1,6 +1,4 @@
-'use strict';
-
-var TabStore = require('../../src/background/tab-store');
+import TabStore from '../../src/background/tab-store';
 
 describe('TabStore', function() {
   var store;

--- a/tests/background/uri-info-test.js
+++ b/tests/background/uri-info-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var toResult = require('../promise-util').toResult;
-var unroll = require('../util').unroll;
+var { toResult } = require('../promise-util');
+var { unroll } = require('../util');
 
 var uriInfo = require('../../src/background/uri-info');
 var settings = require('../settings.json');

--- a/tests/background/uri-info-test.js
+++ b/tests/background/uri-info-test.js
@@ -1,10 +1,7 @@
-'use strict';
-
-var { toResult } = require('../promise-util');
-var { unroll } = require('../util');
-
-var uriInfo = require('../../src/background/uri-info');
-var settings = require('../settings.json');
+import * as uriInfo from '../../src/background/uri-info';
+import { toResult } from '../promise-util';
+import settings from '../settings.json';
+import { unroll } from '../util';
 
 describe('UriInfo.query', function() {
   var badgeURL = settings.apiUrl + '/badge';

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -61,7 +61,7 @@ module.exports = function(config) {
           // defaults in .babelrc to enable ES2015 => ES5 transformation for all
           // language features.
           presets: ['env'],
-          plugins: ['mockable-imports'],
+          plugins: [['mockable-imports', { excludeDirs: ['tests'] }]],
         });
       },
     },


### PR DESCRIPTION
For consistency with our other projects, modernize the background page sources, which constitute most of the extensions' code, to use ES modules. There are a few other single-file scripts which are used in different contexts and have been left alone as they don't import anything.

This mostly uses the same `convert-to-es-modules` conversion script from the hypothesis/frontend-toolkit repo that was used for the client. I had to apply some of the same fixes to the codebase (eg. hoisting imports to the top level) that were also applied in the client.