### PR TITLE
Specify language of sidebar, Help and Options pages

### DIFF
--- a/src/help/index.html
+++ b/src/help/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Hypothesis Help</title>

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>Hypothesis Extension Settings</title>
   <style>

--- a/src/sidebar-app.html.mustache
+++ b/src/sidebar-app.html.mustache
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8">
     {{! At the moment we use Angular's $location service in HTML5 mode with


### PR DESCRIPTION
Specify the language of the sidebar HTML page and the extension's Help
and Options pages. This helps screen readers choose an appropriate voice
to read the UI amongst other things.

This is currently always English.

See also https://github.com/hypothesis/h/pull/5906.

Part of https://github.com/hypothesis/client/issues/1794.