### PR TITLE
Add Jenkins build/test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# We use Alpine as a base image and then install Node separately
+# rather than using a Node base image because this enables automated tools to
+# upgrade everything by simply updating the Alpine version.
+#
+# Alpine is updated every 6 months so all packages are pretty recent.
+FROM alpine:3.10
+
+RUN apk update && apk add --no-cache \
+  chromium \
+  git \
+  make \
+  nodejs \
+  npm \
+  zip
+
+# Do not download a Chrome build as part of installing the "puppeteer" package,
+# it won't work in Alpine.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
+# Enable test scripts to detect that they are running from the Docker image.
+ENV RUNNING_IN_DOCKER true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,65 @@
+#!groovy
+
+node {
+    checkout scm
+
+    workspace = pwd()
+
+    // Git branch which releases are deployed from.
+    releaseFromBranch = "master"
+
+    sh "docker build -t hypothesis-browser-extension-tests ."
+    nodeEnv = docker.image("hypothesis-browser-extension-tests")
+
+    stage('Setup') {
+      nodeEnv.inside("-e HOME=${workspace}") {
+        sh "npm ci"
+      }
+    }
+
+    stage('Test') {
+        nodeEnv.inside("-e HOME=${workspace}") {
+          sh "make checkformatting lint test"
+        }
+    }
+
+    stage('Build Packages') {
+        nodeEnv.inside("-e HOME=${workspace}") {
+          sh "make SETTINGS_FILE=settings/chrome-stage.json dist/chrome-stage.zip"
+          sh "make SETTINGS_FILE=settings/chrome-prod.json dist/chrome-prod.zip"
+          sh "make SETTINGS_FILE=settings/firefox-stage.json dist/firefox-stage.xpi"
+          sh "make SETTINGS_FILE=settings/firefox-prod.json dist/firefox-prod.xpi"
+        }
+    }
+}
+
+if (env.BRANCH_NAME != releaseFromBranch) {
+    echo "Skipping deployment because ${env.BRANCH_NAME} is not the ${releaseFromBranch} branch"
+    return
+}
+
+milestone()
+stage('Upload Packages') {
+    node {
+        nodeEnv.inside("-e HOME=${workspace}") {
+            // TODO -  Add credentials for Chrome Web Store and addons.mozilla.org uploads
+            // using `withCredentials`. The following env vars need to be set:
+            //
+            // - CHROME_WEBSTORE_CLIENT_ID
+            // - CHROME_WEBSTORE_CLIENT_SECRET
+            // - CHROME_WEBSTORE_REFRESH_TOKEN
+            // - FIREFOX_AMO_KEY
+            // - FIREFOX_AMO_SECRET
+
+            echo "Deployment step not implemented"
+
+            // TODO - Upload the QA + prod build packages to the Chrome Web Store
+            // and sign the Firefox builds. Publish the QA packages.
+
+            // sh "tools/deploy"
+        }
+    }
+}
+
+// TODO: Add a final step here which publishes the production package, saving
+// the need to login to the Chrome dashboard to do this.


### PR DESCRIPTION
This is part of https://github.com/hypothesis/browser-extension/issues/247.

As part of automating more of the process of building and deploying the extension, including the process of updating the extension when a new build of the Hypothesis client is released, create a Jenkins build for the extension. This mostly involved following the relevant parts of [our documentation for adding a new Jenkins project](https://github.com/hypothesis/playbook/blob/master/docs/deploying-a-new-app.md#add-a-jenkinsfile-to-your-app-for-continuous-integration) and copying / adapting relevant files from the client repository.

This PR only implements the steps to run tests and build the extension zip archives which are run for all PRs. Moving the deployment for builds on the master branch from Travis to Jenkins will happen separately. I also plan to add a custom build type which updates the Hypothesis client version that is triggered in response to a successful client release to production.

Once the Jenkins build is fully working, we can remove the Travis build.