### PR TITLE
Move extension deployment to Jenkins

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 build/**
+dist/*
 **/vendor/**/*.js
 
 # Ignore PDF.js build

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,3 @@ addons:
     paths:
       # Upload all built extension packages
       - $(ls dist/*.zip dist/*.xpi | tr "\n" ":")
-deploy:
-  skip_cleanup: true
-  provider: script
-  script: sh -x ./tools/deploy
-  on:
-    branch: master

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 #!groovy
 
 node {
+    deleteDir()
     checkout scm
 
     workspace = pwd()
@@ -37,10 +38,6 @@ node {
 
     stage('Build Packages') {
         nodeEnv.inside("-e HOME=${workspace}") {
-          // FIXME - We should ensure that each build runs in a fresh workspace
-          // so old files don't need to be cleared out manually.
-          sh "rm -rf dist/*"
-
           sh "make SETTINGS_FILE=settings/chrome-stage.json dist/${gitVersion}-chrome-stage.zip"
           sh "make SETTINGS_FILE=settings/chrome-prod.json dist/${gitVersion}-chrome-prod.zip"
           sh "make SETTINGS_FILE=settings/firefox-stage.json dist/${gitVersion}-firefox-stage.xpi"

--- a/tools/deploy
+++ b/tools/deploy
@@ -41,7 +41,7 @@ upload_chrome_prod_ext() {
 sign_firefox_ext() {
   FIREFOX_STAGE_EXT_ID="{b441de5f-18e6-40ad-a8c2-f1bd2d42cb01}"
   rm -rf dist/firefox-stage
-  unzip dist/*-firefox-stage.xpi -d dist/firefox-stage
+  unzip -q dist/*-firefox-stage.xpi -d dist/firefox-stage
 
   ./node_modules/.bin/web-ext sign \
    --api-key $FIREFOX_AMO_KEY \
@@ -52,7 +52,7 @@ sign_firefox_ext() {
 
   FIREFOX_PROD_EXT_ID="{32492fee-2d9f-49fe-b268-fe213f7019f0}"
   rm -rf dist/firefox-prod
-  unzip dist/*-firefox-prod.xpi -d dist/firefox-prod
+  unzip -q dist/*-firefox-prod.xpi -d dist/firefox-prod
 
   ./node_modules/.bin/web-ext sign \
     --api-key $FIREFOX_AMO_KEY \
@@ -62,6 +62,11 @@ sign_firefox_ext() {
     --artifacts-dir dist/firefox-prod
 }
 
+echo "Uploading and publishing Chrome (QA) extension..."
 upload_and_publish_chrome_stage_ext
+
+echo "Uploading Chrome (prod) extension..."
 upload_chrome_prod_ext
+
+echo "Signing Firefox extension..."
 sign_firefox_ext


### PR DESCRIPTION
As the next step in moving our browser extension deployment process from
Travis to Jenkins, move the extension upload and publish steps.

The credentials are listed under the [browser-extension project](https://jenkins.hypothes.is/job/browser-extension/credentials/store/folder/domain/_/).