### PR TITLE
Remove obsolete reference to FTP

### DIFF
--- a/src/help/index.html
+++ b/src/help/index.html
@@ -110,7 +110,8 @@
         <img class="help-item__icon" src="sad-annotation.svg" />
         <h1 class="help-item__heading">We’re sorry, Hypothesis doesn’t work on this page…</h1>
         <p class="center">
-          This extension can only be used on pages served over HTTP/HTTPS and FTP.
+          This extension can only be used on pages where the URL starts with "http:",
+          "https:" or "file:".
         </p>
         <p class="center">
           If you have a Chrome extension installed that provides a custom viewer


### PR DESCRIPTION
FTP support is being removed from Chrome (see
https://www.ghacks.net/2019/08/16/google-chrome-82-wont-support-ftp-anymore/)

Also re-word the error message slightly to be clearer about the protocol
restriction.