### PR TITLE
Rename "stage" extension to "QA"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ script:
   - make lint
   - npm test
   - make SETTINGS_FILE=settings/chrome-prod.json dist/$(date +'%Y%m%d')-chrome-prod.zip
-  - make SETTINGS_FILE=settings/chrome-stage.json dist/$(date +'%Y%m%d')-chrome-stage.zip
+  - make SETTINGS_FILE=settings/chrome-qa.json dist/$(date +'%Y%m%d')-chrome-qa.zip
   - make SETTINGS_FILE=settings/firefox-prod.json dist/$(date +'%Y%m%d')-firefox-prod.xpi
-  - make SETTINGS_FILE=settings/firefox-stage.json dist/$(date +'%Y%m%d')-firefox-stage.xpi
+  - make SETTINGS_FILE=settings/firefox-qa.json dist/$(date +'%Y%m%d')-firefox-qa.xpi
 addons:
   artifacts:
     paths:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,9 +98,9 @@ node {
 
     stage('Build Packages') {
         nodeEnv.inside("-e HOME=${workspace}") {
-          sh "make SETTINGS_FILE=settings/chrome-stage.json dist/${gitVersion}-chrome-stage.zip"
+          sh "make SETTINGS_FILE=settings/chrome-qa.json dist/${gitVersion}-chrome-qa.zip"
           sh "make SETTINGS_FILE=settings/chrome-prod.json dist/${gitVersion}-chrome-prod.zip"
-          sh "make SETTINGS_FILE=settings/firefox-stage.json dist/${gitVersion}-firefox-stage.xpi"
+          sh "make SETTINGS_FILE=settings/firefox-qa.json dist/${gitVersion}-firefox-qa.xpi"
           sh "make SETTINGS_FILE=settings/firefox-prod.json dist/${gitVersion}-firefox-prod.xpi"
         }
     }

--- a/settings/chrome-qa.json
+++ b/settings/chrome-qa.json
@@ -1,5 +1,5 @@
 {
-  "buildType": "staging",
+  "buildType": "qa",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqjbEOhG+ZCl2Bl17m2ltNC+3uw0Fqv3Dzuja5vLnH1MLBRQG7L77pXtKCZgVgFJ2K+Kn0L0OqnMDcKEi5pUpNTi39b8twp1imDsoLO+L5XgpKYBtUgfR+T8OO2INjEgz0LDth0l26WmHNS377KZjSTsfPWNnLozXHHkETgug1lt9VzgcvSboiyZuwk23xHmiqnVpZtuqVAv4HdqFofHiNQn2fF7awsQxEYYNfuSk0Jp33XJkkadyrJ/dQ7vVFi0F0O//Oyaw3s4TD58frABxznusmKkjHZorJUrm2OaYbn/7TSUcG5fReQC08fXiMsFGUKxK01HfAwdmVUAmASL+NwIDAQAB",
 
   "apiUrl": "https://qa.hypothes.is/api/",

--- a/settings/firefox-qa.json
+++ b/settings/firefox-qa.json
@@ -1,9 +1,9 @@
 {
-  "buildType": "staging",
+  "buildType": "qa",
 
   "apiUrl": "https://qa.hypothes.is/api/",
   "authDomain": "hypothes.is",
-  "bouncerUrl": "https://stage.hyp.is/",
+  "bouncerUrl": "https://qa.hyp.is/",
   "serviceUrl": "https://qa.hypothes.is/",
   "websocketUrl": "wss://qa.hypothes.is/ws",
 

--- a/src/background/browser-action.js
+++ b/src/background/browser-action.js
@@ -23,8 +23,8 @@ var badgeThemes = {
     defaultText: 'DEV',
     color: '#5BCF59', // Emerald green
   },
-  staging: {
-    defaultText: 'STG',
+  qa: {
+    defaultText: 'QA',
     color: '#EDA061', // Porche orange-pink
   },
 };

--- a/tests/background/browser-action-test.js
+++ b/tests/background/browser-action-test.js
@@ -158,7 +158,7 @@ describe('BrowserAction', function() {
   describe('build type', function() {
     beforeEach(function() {
       var fakeSettings = {
-        buildType: 'staging',
+        buildType: 'qa',
       };
       $imports.$mock({
         './settings': {
@@ -172,12 +172,12 @@ describe('BrowserAction', function() {
       $imports.$restore();
     });
 
-    it('sets the text to STG when there are no annotations', function() {
+    it('sets the text to QA when there are no annotations', function() {
       action.update(1, {
         state: TabState.states.INACTIVE,
         annotationCount: 0,
       });
-      assert.equal(fakeChromeBrowserAction.badgeText, 'STG');
+      assert.equal(fakeChromeBrowserAction.badgeText, 'QA');
     });
 
     it('shows the annotation count when there are annotations', function() {

--- a/tools/deploy
+++ b/tools/deploy
@@ -2,20 +2,20 @@
 
 set -eu
 
-CHROME_STAGE_EXT_ID=iahhmhdkmkifclacffbofcnmgkpalpoj
+CHROME_QA_EXT_ID=iahhmhdkmkifclacffbofcnmgkpalpoj
 CHROME_PROD_EXT_ID=bjfhmglciegochdpefhhlphglcehbmek
 
-upload_and_publish_chrome_stage_ext() {
-  # Upload and publish stage extension
-  CHROME_STAGE_EXT_ARCHIVE=dist/*-chrome-stage.zip
-  if [ ! -f $CHROME_STAGE_EXT_ARCHIVE ]; then
-    echo "Chrome stage extension has not been built."
+upload_and_publish_chrome_qa_ext() {
+  # Upload and publish qa extension
+  CHROME_QA_EXT_ARCHIVE=dist/*-chrome-qa.zip
+  if [ ! -f $CHROME_QA_EXT_ARCHIVE ]; then
+    echo "Chrome qa extension has not been built."
     exit 1
   fi
 
 ./node_modules/.bin/webstore upload \
-  --source $CHROME_STAGE_EXT_ARCHIVE \
-  --extension-id $CHROME_STAGE_EXT_ID \
+  --source $CHROME_QA_EXT_ARCHIVE \
+  --extension-id $CHROME_QA_EXT_ID \
   --client-id $CHROME_WEBSTORE_CLIENT_ID \
   --client-secret $CHROME_WEBSTORE_CLIENT_SECRET \
   --refresh-token $CHROME_WEBSTORE_REFRESH_TOKEN \
@@ -39,16 +39,16 @@ upload_chrome_prod_ext() {
 }
 
 sign_firefox_ext() {
-  FIREFOX_STAGE_EXT_ID="{b441de5f-18e6-40ad-a8c2-f1bd2d42cb01}"
-  rm -rf dist/firefox-stage
-  unzip -q dist/*-firefox-stage.xpi -d dist/firefox-stage
+  FIREFOX_QA_EXT_ID="{b441de5f-18e6-40ad-a8c2-f1bd2d42cb01}"
+  rm -rf dist/firefox-qa
+  unzip -q dist/*-firefox-qa.xpi -d dist/firefox-qa
 
   ./node_modules/.bin/web-ext sign \
    --api-key $FIREFOX_AMO_KEY \
    --api-secret $FIREFOX_AMO_SECRET \
-   --id "$FIREFOX_STAGE_EXT_ID" \
-   --source-dir dist/firefox-stage \
-   --artifacts-dir dist/firefox-stage
+   --id "$FIREFOX_QA_EXT_ID" \
+   --source-dir dist/firefox-qa \
+   --artifacts-dir dist/firefox-qa
 
   FIREFOX_PROD_EXT_ID="{32492fee-2d9f-49fe-b268-fe213f7019f0}"
   rm -rf dist/firefox-prod
@@ -63,7 +63,7 @@ sign_firefox_ext() {
 }
 
 echo "Uploading and publishing Chrome (QA) extension..."
-upload_and_publish_chrome_stage_ext
+upload_and_publish_chrome_qa_ext
 
 echo "Uploading Chrome (prod) extension..."
 upload_chrome_prod_ext


### PR DESCRIPTION
We use the term "QA" rather than "staging" to refer to our
pre-production test environment for all other Hypothesis projects.
Rename the QA extension accordingly to avoid confusion.

 - Rename all references to the "stage" extension to "QA" to refer
 - Change the browser action label for the QA extension from "STG" to
   "QA"
 - Fix an invalid URL for the QA bouncer service