### PR TITLE
Simplify Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,10 @@
 language: node_js
 node_js: 'lts/*'
-cache:
-  directories:
-    - $HOME/.npm
 install:
-  - npm install -g npm
   - npm ci
 script:
-  - make checkformatting
-  - make lint
-  - npm test
-  - make SETTINGS_FILE=settings/chrome-prod.json dist/$(date +'%Y%m%d')-chrome-prod.zip
-  - make SETTINGS_FILE=settings/chrome-qa.json dist/$(date +'%Y%m%d')-chrome-qa.zip
-  - make SETTINGS_FILE=settings/firefox-prod.json dist/$(date +'%Y%m%d')-firefox-prod.xpi
-  - make SETTINGS_FILE=settings/firefox-qa.json dist/$(date +'%Y%m%d')-firefox-qa.xpi
-addons:
-  artifacts:
-    paths:
-      # Upload all built extension packages
-      - $(ls dist/*.zip dist/*.xpi | tr "\n" ":")
+  - make checkformatting lint test
+  - make SETTINGS_FILE=settings/chrome-prod.json dist/chrome-prod.zip
+  - make SETTINGS_FILE=settings/chrome-qa.json dist/chrome-qa.zip
+  - make SETTINGS_FILE=settings/firefox-prod.json dist/firefox-prod.xpi
+  - make SETTINGS_FILE=settings/firefox-qa.json dist/firefox-qa.xpi


### PR DESCRIPTION
Even though Jenkins is our primary CI for internal usage, we keep Travis
around to run checks in case any external developers propose changes,
since Travis is externally accessible and the maintenance effort has
been low.

This simplifies the configuration a bit though since we no longer use
the built artifacts and the caching configuration/npm update is no
longer needed.