### PR TITLE
Activate extension when following direct link to public group

### DIFF
--- a/src/background/direct-link-query.js
+++ b/src/background/direct-link-query.js
@@ -37,8 +37,9 @@ export default function directLinkQuery(url) {
   }
 
   // Group IDs (and other "pubids" in h) are a subset of ASCII letters and
-  // digits.
-  var groupMatch = url.match(/#annotations:group:([A-Za-z0-9]+)$/);
+  // digits. As a special exception, the "Public" group has underscores in its
+  // ID ("__world__").
+  var groupMatch = url.match(/#annotations:group:([A-Za-z0-9_]+)$/);
   if (groupMatch) {
     return { group: groupMatch[1] };
   }

--- a/tests/background/direct-link-query-test.js
+++ b/tests/background/direct-link-query-test.js
@@ -27,10 +27,12 @@ describe('common.direct-link-query', () => {
     });
   });
 
-  it('returns the group ID if the URL contains a #annotations:group:<ID> fragment', () => {
-    var url = 'https://example.com/#annotations:group:123';
-    assert.deepEqual(directLinkQuery(url), {
-      group: '123',
+  ['123', 'abcDEF456', '__world__'].forEach(groupId => {
+    it('returns the group ID if the URL contains a #annotations:group:<ID> fragment', () => {
+      var url = `https://example.com/#annotations:group:${groupId}`;
+      assert.deepEqual(directLinkQuery(url), {
+        group: groupId,
+      });
     });
   });
 


### PR DESCRIPTION
Unlike all groups with [randomly generated pubids](https://github.com/hypothesis/h/blob/6eb5dee986e3e786c095382e54a5ad2781dfbd42/h/pubid.py#L33), the public group's
pubid contains underscores, which caused the extension's URL fragment matching to fail.

There is a broader issue around whether the extension should have to know about the character set of various kinds of identifier or even all the possible syntaxes of an `#annotations:` fragment. For the moment, this PR just implements the minimal fix plus a test.

Fixes https://github.com/hypothesis/bouncer/issues/323