### PR TITLE
Remove `<base>` tag from sidebar HTML template

### DIFF
--- a/src/sidebar-app.html.mustache
+++ b/src/sidebar-app.html.mustache
@@ -2,10 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    {{! At the moment we use Angular's $location service in HTML5 mode with
-        html5Mode.requireBase left at its default value (true), so this is
-        required. In future we should be able to remove this. }}
-    <base href="/">
   </head>
   <body>
     <hypothesis-app></hypothesis-app>


### PR DESCRIPTION
This is no longer used by the client as it doesn't use AngularJS for
routing or URL management any more.