### PR TITLE
Fix possible deploy from incorrect workspace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,21 +104,19 @@ node {
           sh "make SETTINGS_FILE=settings/firefox-prod.json dist/${gitVersion}-firefox-prod.xpi"
         }
     }
-}
 
-if (params.BUILD_TYPE != "build") {
-    echo "Skipping deployment because this is not a regular build"
-    return
-}
+    if (params.BUILD_TYPE != "build") {
+        echo "Skipping deployment because this is not a regular build"
+        return
+    }
 
-if (env.BRANCH_NAME != releaseFromBranch) {
-    echo "Skipping deployment because ${env.BRANCH_NAME} is not the ${releaseFromBranch} branch"
-    return
-}
+    if (env.BRANCH_NAME != releaseFromBranch) {
+        echo "Skipping deployment because ${env.BRANCH_NAME} is not the ${releaseFromBranch} branch"
+        return
+    }
 
-milestone()
-stage('Upload Packages') {
-    node {
+    milestone()
+    stage('Upload Packages') {
         nodeEnv.inside("-e HOME=${workspace}") {
             withCredentials([
                 // Credentials for Chrome Web Store API calls.


### PR DESCRIPTION
Fix an issue where the Jenkins build could fail the "Upload Package"
step or attempt to upload packages from a previous build in this step.

This issue arose because the build used two separate `node` blocks and
the second `node` block assumed it was using the same workspace
directory with the same contents as the first `node` block.

The fix is just to use one `node` block for the whole build.

The only reason to use separate `node` blocks is to free up an executor
while awaiting manual approval for a deployment. We currently don't do
that at any point during an extension build, although we likely will if
we make it possible to deploy to prod from Jenkins rather than from the
Chrome Web Store developer dashboard.

If you want a fuller explanation of the general issue, please see the notes on https://github.com/hypothesis/client/pull/2040.