### PR TITLE
Fix bug #260: If "Missing host permission for the tab" error, assume PDF

### DIFF
--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -173,6 +173,14 @@ export default function SidebarInjector(chromeTabs, dependencies) {
             // tab URL
             return guessContentTypeFromURL(tab.url);
           }
+        }, function(error) {
+          if (error.message === 'Missing host permission for the tab') {
+            // Assume that any file or http URLs that trigger this error
+            // (ie. not a protected scheme) are PDFs. See issue #260.
+            return CONTENT_TYPE_PDF;
+          } else {
+            return guessContentTypeFromURL(tab.url);
+          }
         });
       } else {
         // We cannot inject a content script in order to determine the

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -179,7 +179,7 @@ export default function SidebarInjector(chromeTabs, dependencies) {
             // (ie. not a protected scheme) are PDFs. See issue #260.
             return CONTENT_TYPE_PDF;
           } else {
-            return guessContentTypeFromURL(tab.url);
+            throw error;
           }
         });
       } else {


### PR DESCRIPTION
As suggested in issue #260, this fix assumes type is PDF if url is `file` or `http` scheme and "Missing host permissions for tab" error is returned.

Although this does seem to fix the bug for remote PDFs (see unofficial release [here](https://github.com/diegodlh/browser-extension/releases/tag/v1.441.0.10)), it doesn't for local PDFs because of issue #100: Firefox [cannot](https://wiki.mozilla.org/WebExtensions/Filesystem#Accessing_file:.2F.2F_in_tabs_and_content_scripts) call file URLs in tabs APIs, e.g.: tabs.create or tabs.update, and tabs.update seems to be the method used to reload the pdf with the extension's PDF viewer.