### PR TITLE
Return Firefox-specific error page for local PDFs

### DIFF
--- a/src/background/help-page.js
+++ b/src/background/help-page.js
@@ -23,7 +23,11 @@ export default function HelpPage(chromeTabs, extensionURL, browserName_) {
     if (error instanceof errors.LocalFileError) {
       return this.showLocalFileHelpPage(tab);
     } else if (error instanceof errors.NoFileAccessError) {
-      return this.showNoFileAccessHelpPage(tab);
+      if (browserName_() === 'firefox') {
+        return this.showNoFileAccessFirefoxHelpPage(tab);
+      } else {
+        return this.showNoFileAccessHelpPage(tab);
+      }
     } else if (error instanceof errors.RestrictedProtocolError) {
       return this.showRestrictedProtocolPage(tab);
     } else if (error instanceof errors.BlockedSiteError) {
@@ -35,6 +39,7 @@ export default function HelpPage(chromeTabs, extensionURL, browserName_) {
 
   this.showLocalFileHelpPage = showHelpPage.bind(null, 'local-file');
   this.showNoFileAccessHelpPage = showHelpPage.bind(null, 'no-file-access');
+  this.showNoFileAccessFirefoxHelpPage = showHelpPage.bind(null, 'no-file-access-firefox');
   this.showRestrictedProtocolPage = showHelpPage.bind(
     null,
     'restricted-protocol'

--- a/src/help/index.html
+++ b/src/help/index.html
@@ -101,6 +101,17 @@
           </li>
         </ol>
       </section>
+      <section id="no-file-access-firefox" class="help-item">
+        <img class="help-item__icon" src="sad-annotation.svg" />
+        <h1 class="help-item__heading">We’re sorry, Hypothesis couldn’t open that file…</h1>
+        <p>If it’s a local PDF document that you’ve opened from your computer,
+          unfortunately this is not yet supported in this Firefox extension.
+        </p>
+        <p>You can use the
+          <a href="https://web.hypothes.is/help/installing-the-bookmarklet/">bookmarklet</a>
+          instead.
+        </p>
+      </section>
       <section id="local-file" class="help-item">
         <img class="help-item__icon" src="sad-annotation.svg" />
         <h1 class="help-item__heading">We’re sorry, Hypothesis couldn’t open that file…</h1>


### PR DESCRIPTION
As mentioned in #100, the Firefox extension returns a Chrome-specific error page if the user tries to annotate a local PDF. This is not supported in Firefox (see #100) and the instructions in the error page returned do not apply to this browser.

The fix proposed here returns a Firefox-specific error page if the browser detected is Firefox.