### PR TITLE
Reduce the number of badge requests

### DIFF
--- a/src/background/uri-info.js
+++ b/src/background/uri-info.js
@@ -1,14 +1,14 @@
 import settings from './settings';
 
-const BLOCKLIST = [
-  /* browser-specific URLs don't correspond to a meaningful document to annotate */
-  { urlProperty: 'protocol', value: 'chrome:' },
-  /* The following sites are personal in nature, high potential traffic
-     and URLs don't correspond to identifiable content */
-  { urlProperty: 'hostname', value: 'facebook.com' },
-  { urlProperty: 'hostname', value: 'www.facebook.com' },
-  { urlProperty: 'hostname', value: 'mail.google.com' },
-];
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+// The following sites are personal in nature, high potential traffic
+// and URLs don't correspond to identifiable content
+const BLOCKED_HOSTNAMES = new Set([
+  'facebook.com',
+  'www.facebook.com',
+  'mail.google.com',
+]);
 
 /** encodeUriQuery encodes a string for use in a query parameter */
 function encodeUriQuery(val) {
@@ -16,11 +16,11 @@ function encodeUriQuery(val) {
 }
 
 /**
- * Should we send a "badge" request to obtain the annotation count for the
- * URL `uri`?
+ * Based on the request protocol and hostname decide if the URL should be sent to the "badge"
+ * request endpoint.
  *
  * @param {string} uri
- * @return {boolean}
+ * @return {boolean} - false if the URL should not be sent to the "badge" request endpoint
  */
 function shouldQueryUri(uri) {
   let url;
@@ -31,43 +31,51 @@ function shouldQueryUri(uri) {
     return false;
   }
 
-  // Make sure `uri` does not match ANY item in the blocklist
-  return BLOCKLIST.every(
-    blockedItem => url[blockedItem.urlProperty] !== blockedItem.value
-  );
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
+    return false;
+  }
+
+  if (BLOCKED_HOSTNAMES.has(url.hostname)) {
+    return false;
+  }
+
+  return true;
 }
 
 /**
  * Queries the Hypothesis service that provides
  * statistics about the annotations for a given URL.
+ *
+ * @return {Promise<number>}
  */
-function query(uri) {
-  return fetch(settings.apiUrl + '/badge?uri=' + encodeUriQuery(uri), {
-    credentials: 'include',
-  }).then(res => res.json());
+async function query(uri) {
+  const response = await fetch(
+    settings.apiUrl + '/badge?uri=' + encodeUriQuery(uri),
+    {
+      credentials: 'include',
+    }
+  );
+
+  const data = await response.json();
+
+  if (data && typeof data.total === 'number') {
+    return data.total;
+  }
+
+  throw new Error('Unable to parse badge response');
 }
 
 /**
  * Retrieve the count of available annotations for `uri`
  *
  * @return {Promise<number>} - Annotation count for `uri`. Will be 0 if URI
- *                             has a blocklist match or there are problems with
- *                             the request to or response from the API
+ *                             has a blocklist match.
+ * @throws Will throw a variety of errors: network, json parsing, or wrong format errors.
  */
 export function getAnnotationCount(uri) {
-  const noValue = 0;
-  if (shouldQueryUri(uri)) {
-    return query(uri)
-      .then(data => {
-        if (!data || typeof data.total !== 'number') {
-          return noValue;
-        }
-        return data.total;
-      })
-      .catch(() => {
-        return noValue;
-      });
-  } else {
-    return Promise.resolve(noValue);
+  if (!shouldQueryUri(uri)) {
+    return Promise.resolve(0);
   }
+
+  return query(uri);
 }

--- a/tests/background/uri-info-test.js
+++ b/tests/background/uri-info-test.js
@@ -45,27 +45,32 @@ describe('background/uri-info', () => {
     });
 
     [
-      'chrome://extensions',
-      'chrome://newtab',
       'http://www.facebook.com',
       'https://facebook.com',
       'https://mail.google.com',
       'http://www.facebook.com/some/page/',
     ].forEach(badURI => {
-      it('does not send request to API if URI matches blocklist entries', () => {
-        uriInfo.getAnnotationCount(badURI);
+      it('does not send request to API if URI matches blocklist entries', async () => {
+        assert.strictEqual(await uriInfo.getAnnotationCount(badURI), 0);
         assert.equal(fetchStub.callCount, 0);
       });
     });
 
     [
-      'https://www.google.com',
-      'file://whatever',
-      'http://www.example.com',
+      'chrome://extensions',
+      'chrome://newtab',
       'chrome-extension://fadpmhkjbfijelnpfnjmnghgokbppplf/pdfjs/web/viewer.html?file=http%3A%2F%2Fwww.pdf995.com%2Fsamples%2Fpdf.pdf',
-    ].forEach(okURI => {
-      it('sends request to API if URI does not match blocklist entries', () => {
-        uriInfo.getAnnotationCount(okURI);
+      'file://whatever',
+    ].forEach(badURI => {
+      it('does not send request to API if URI does not have an allowed protocol', async () => {
+        assert.strictEqual(await uriInfo.getAnnotationCount(badURI), 0);
+        assert.equal(fetchStub.callCount, 0);
+      });
+    });
+
+    ['https://www.google.com', 'http://www.example.com'].forEach(okURI => {
+      it('sends request to API if URI does not match blocklist entries and has an allowed protocol', async () => {
+        assert.strictEqual(await uriInfo.getAnnotationCount(okURI), 1);
         assert.equal(fetchStub.callCount, 1);
       });
     });
@@ -78,34 +83,48 @@ describe('background/uri-info', () => {
         });
     });
 
-    [
-      'this is not valid json',
-      '{"total": "not a valid number"}',
-      '{"rows": []}',
-      '{"foop": 5}',
-    ].forEach(badBody => {
-      it('warns if result is invalid and returns 0', () => {
-        fetchStub.resolves(
-          new Response(badBody, {
-            status: 200,
-            headers: {},
-          })
-        );
-        return uriInfo
-          .getAnnotationCount('http://www.example.com')
-          .then(result => {
-            assert.equal(result, 0);
-          });
-      });
+    ['{"total": "not a valid number"}', '{"rows": []}', '{"foop": 5}'].forEach(
+      badBody => {
+        it('throws an error if the reponse has an incorrect format', () => {
+          fetchStub.resolves(
+            new Response(badBody, {
+              status: 200,
+              headers: {},
+            })
+          );
+          return uriInfo
+            .getAnnotationCount('http://www.example.com')
+            .catch(error => {
+              assert.strictEqual(
+                error.message,
+                'Unable to parse badge response'
+              );
+            });
+        });
+      }
+    );
+
+    it('throws an error if the reponse is not valid JSON', () => {
+      fetchStub.resolves(
+        new Response('this is not valid json', {
+          status: 200,
+          headers: {},
+        })
+      );
+      return uriInfo
+        .getAnnotationCount('http://www.example.com')
+        .catch(error => {
+          assert.instanceOf(error, SyntaxError);
+        });
     });
 
-    it('warns if fetch throws and returns 0', () => {
-      fetchStub.rejects();
+    it('throws errors for other fetch failures', () => {
+      fetchStub.rejects('Network error');
 
       return uriInfo
         .getAnnotationCount('http://www.example.com')
-        .then(result => {
-          assert.equal(result, 0);
+        .catch(error => {
+          assert.strictEqual(error.name, 'Network error');
         });
     });
   });


### PR DESCRIPTION
It implements a custom debouncing mechanism.

A more standard approach like using `lodash._debounce` is not suited for
this particular case, because TabState is shared amoung all the tabs.

Reloading two tabs simulatneously shouldn't make one of the requests
to be cancelled.

The cancellation of a pending request could happen during the
waiting period or in-flight badge request.

Resolves #396