### PR TITLE
Use same compilation settings in tests and bundle build

### DIFF
--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -63,15 +63,19 @@ module.exports = function (config) {
 
     browserify: {
       debug: true,
-      configure: function (bundle) {
-        bundle.transform('babelify', {
-          plugins: [['mockable-imports', { excludeDirs: ['tests'] }]],
+      transform: [
+        [
+          'babelify',
+          {
+            extensions: ['.js'],
+            plugins: [['mockable-imports', { excludeDirs: ['tests'] }]],
 
-          // Enable Babel to load configuration from the `.babelrc` file when
-          // processing source files outside of the `tests/` directory.
-          root: `${__dirname}/../`,
-        });
-      },
+            // Enable Babel to load configuration from the `.babelrc` file when
+            // processing source files outside of the `tests/` directory.
+            root: `${__dirname}/../`,
+          },
+        ],
+      ],
     },
 
     mochaReporter: {

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global process */
+/* global __dirname, process */
 
 let chromeFlags = [];
 
@@ -65,11 +65,11 @@ module.exports = function (config) {
       debug: true,
       configure: function (bundle) {
         bundle.transform('babelify', {
-          // Use the "env" preset without any browsers listed, overriding the
-          // defaults in .babelrc to enable ES2015 => ES5 transformation for all
-          // language features.
-          presets: ['@babel/preset-env'],
           plugins: [['mockable-imports', { excludeDirs: ['tests'] }]],
+
+          // Enable Babel to load configuration from the `.babelrc` file when
+          // processing source files outside of the `tests/` directory.
+          root: `${__dirname}/../`,
         });
       },
     },


### PR DESCRIPTION
Remove the `presets` override in `karma.config.js` and resolve an issue
that prevented configuration in the `.babelrc` file being used for
source files located outside of the `tests/` directory.

Using the same compilation settings ensures that the test environment
better matches the actual build. It also fixes a problem with using
async/await syntax and other modern JS syntax in tests / code being
tested.

Slack debugging thread: https://hypothes-is.slack.com/archives/D01AJ11PUER/p1603459022001600