### PR TITLE
Correct `yarn version` syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,8 +57,7 @@ node {
 
                 // nb. Any additional steps to test the new client release with
                 // the extension can go here.
-
-                sh "yarn --no-git-tag-version version ${newClientVersion}"
+                sh "yarn version --no-git-tag-version --new-version ${newClientVersion}"
             }
 
             withCredentials([


### PR DESCRIPTION
When `npm` was replaced with `yarn`, the syntax for specifying the new
version needed to be updated.

See https://classic.yarnpkg.com/en/docs/cli/version/.