### PR TITLE
Reduce badge request at parent level

### DIFF
--- a/src/background/hypothesis-chrome-extension.js
+++ b/src/background/hypothesis-chrome-extension.js
@@ -153,14 +153,13 @@ export default function HypothesisChromeExtension(dependencies) {
     return activeState;
   }
 
-  function resetTabState(tabId, url) {
+  function resetTabState(tabId) {
     state.setState(tabId, {
       state: activeStateForNavigatedTab(tabId),
       ready: false,
       annotationCount: 0,
       extensionSidebarInstalled: false,
     });
-    updateAnnotationCountIfEnabled(tabId, url);
   }
 
   // This function will be called multiple times as the tab reloads.
@@ -187,6 +186,7 @@ export default function HypothesisChromeExtension(dependencies) {
         ready: true,
         state: newActiveState,
       });
+      updateAnnotationCountIfEnabled(tabId, tab.url);
     }
   }
 

--- a/src/background/uri-info.js
+++ b/src/background/uri-info.js
@@ -1,14 +1,12 @@
 import settings from './settings';
 
-const BLOCKLIST = [
-  /* browser-specific URLs don't correspond to a meaningful document to annotate */
-  { urlProperty: 'protocol', value: 'chrome:' },
-  /* The following sites are personal in nature, high potential traffic
-     and URLs don't correspond to identifiable content */
-  { urlProperty: 'hostname', value: 'facebook.com' },
-  { urlProperty: 'hostname', value: 'www.facebook.com' },
-  { urlProperty: 'hostname', value: 'mail.google.com' },
-];
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+const BLOCK_HOSTNAMES = new Set([
+  'facebook.com',
+  'www.facebook.com',
+  'mail.google.com',
+]);
 
 /** encodeUriQuery encodes a string for use in a query parameter */
 function encodeUriQuery(val) {
@@ -16,11 +14,12 @@ function encodeUriQuery(val) {
 }
 
 /**
- * Should we send a "badge" request to obtain the annotation count for the
- * URL `uri`?
+ * Based on the request protocol and hostname decide if the URL should be sent to the "badge"
+ * request endpoint.
  *
  * @param {string} uri
- * @return {boolean}
+ * @return {boolean} - false if the requested URL is not be sent to the "badge" request,
+ *                     otherwise true.
  */
 function shouldQueryUri(uri) {
   let url;
@@ -31,43 +30,51 @@ function shouldQueryUri(uri) {
     return false;
   }
 
-  // Make sure `uri` does not match ANY item in the blocklist
-  return BLOCKLIST.every(
-    blockedItem => url[blockedItem.urlProperty] !== blockedItem.value
-  );
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
+    return false;
+  }
+
+  if (BLOCK_HOSTNAMES.has(url.hostname)) {
+    return false;
+  }
+
+  return true;
 }
 
 /**
  * Queries the Hypothesis service that provides
  * statistics about the annotations for a given URL.
+ *
+ * @return {Promise<number>}
+ * @throws Will throw a variety of errors: network, json parsing, or wrong format errors.
  */
-function query(uri) {
-  return fetch(settings.apiUrl + '/badge?uri=' + encodeUriQuery(uri), {
-    credentials: 'include',
-  }).then(res => res.json());
+async function query(uri) {
+  const response = await fetch(
+    settings.apiUrl + '/badge?uri=' + encodeUriQuery(uri),
+    {
+      credentials: 'include',
+    }
+  );
+
+  const data = await response.json();
+
+  if (data && typeof data.total === 'number') {
+    return data.total;
+  }
+
+  throw new Error('Badge response has wrong format');
 }
 
 /**
  * Retrieve the count of available annotations for `uri`
  *
  * @return {Promise<number>} - Annotation count for `uri`. Will be 0 if URI
- *                             has a blocklist match or there are problems with
- *                             the request to or response from the API
+ *                             has a blocklist match.
  */
 export function getAnnotationCount(uri) {
-  const noValue = 0;
-  if (shouldQueryUri(uri)) {
-    return query(uri)
-      .then(data => {
-        if (!data || typeof data.total !== 'number') {
-          return noValue;
-        }
-        return data.total;
-      })
-      .catch(() => {
-        return noValue;
-      });
-  } else {
-    return Promise.resolve(noValue);
+  if (!shouldQueryUri(uri)) {
+    return Promise.resolve(0);
   }
+
+  return query(uri);
 }

--- a/tests/background/tab-state-test.js
+++ b/tests/background/tab-state-test.js
@@ -132,23 +132,126 @@ describe('TabState', () => {
   });
 
   describe('#updateAnnotationCount', () => {
-    afterEach(() => {
-      $imports.$restore();
-    });
+    let clock;
+    let getStub;
 
-    it('queries the service and sets the annotation count', () => {
-      const testValue = 42;
-      const getStub = sinon.stub().returns(Promise.resolve(testValue));
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+      getStub = sinon.stub();
       $imports.$mock({
         './uri-info': {
           getAnnotationCount: getStub,
         },
       });
+    });
+
+    afterEach(() => {
+      $imports.$restore();
+      clock.restore();
+    });
+
+    it('queries the service and sets the annotation count after waiting for a period of 3000ms', async () => {
+      const testValue = 42;
+      getStub.resolves(testValue);
       const tabState = new TabState({ 1: { state: states.ACTIVE } });
-      return tabState.updateAnnotationCount(1, 'foobar.com').then(() => {
-        assert.called(getStub);
-        assert.equal(tabState.getState(1).annotationCount, testValue);
+
+      const promise = tabState.updateAnnotationCount(1, 'foobar.com');
+      clock.tick(1010);
+      await promise;
+      assert.called(getStub);
+      assert.equal(tabState.getState(1).annotationCount, testValue);
+    });
+
+    it('cancels the first query (during waiting period) when the service is called two consecutive times for the same tab', async () => {
+      const testValue = 42;
+      getStub.resolves(testValue);
+      const tabState = new TabState({ 1: { state: states.ACTIVE } });
+
+      const promise1 = tabState.updateAnnotationCount(1, 'foobar.com');
+      clock.tick(800); // promise 1 is still waiting when promise2 is called
+      const promise2 = tabState.updateAnnotationCount(1, 'foobar.com');
+      clock.tick(2300);
+      await promise1;
+      assert.strictEqual(tabState.getState(1).annotationCount, 0);
+
+      await promise2;
+      assert.calledOnce(getStub);
+      assert.strictEqual(tabState.getState(1).annotationCount, testValue);
+    });
+
+    it('waits for a maximum of 3000 ms when a number of concurrent requests', async () => {
+      const testValue = 42;
+      getStub.resolves(testValue);
+      const tabState = new TabState({ 1: { state: states.ACTIVE } });
+
+      const promise1 = tabState.updateAnnotationCount(1, 'foobar.com');
+      const promise2 = tabState.updateAnnotationCount(1, 'foobar.com');
+      const promise3 = tabState.updateAnnotationCount(1, 'foobar.com');
+      const promise4 = tabState.updateAnnotationCount(1, 'foobar.com');
+      const promise5 = tabState.updateAnnotationCount(1, 'foobar.com');
+      clock.tick(3010); // promise 1-4 are cancelled, while promise 4 is resolved in no more than 3000 ms
+      await promise1;
+      await promise2;
+      assert.strictEqual(tabState.getState(1).annotationCount, 0);
+      await promise3;
+      await promise4;
+      await promise5;
+      assert.calledOnce(getStub);
+      assert.strictEqual(tabState.getState(1).annotationCount, testValue);
+    });
+
+    it('cancels the first query (during the fetch request) when the service is called two consecutive times for the same tab', async () => {
+      const testValue = 42;
+
+      // Takes 2000ms in returning a the response
+      getStub.returns(
+        new Promise(resolve => setTimeout(() => resolve(testValue), 2000))
+      );
+
+      const tabState = new TabState({ 1: { state: states.ACTIVE } });
+
+      const promise1 = tabState.updateAnnotationCount(1, 'foobar.com');
+      clock.tick(1010); // promise1 finished waiting and it is fetching the request
+      const promise2 = tabState.updateAnnotationCount(1, 'foobar.com');
+      clock.tick(1010 + 2000);
+
+      await promise1;
+      assert.calledTwice(getStub); // request is not cancelled
+      assert.equal(tabState.getState(1).annotationCount, 0);
+      await promise2;
+      assert.equal(tabState.getState(1).annotationCount, testValue);
+    });
+
+    it('processes two consecutive request to the service if the requests are for different tabs', async () => {
+      const testValue = 42;
+      getStub.resolves(testValue);
+
+      const tabState = new TabState({
+        1: { state: states.ACTIVE },
+        2: { state: states.ACTIVE },
       });
+
+      const promise1 = tabState.updateAnnotationCount(1, 'foobar.com');
+      const promise2 = tabState.updateAnnotationCount(2, 'foobar.com');
+      clock.tick(1010);
+      await promise1;
+      assert.strictEqual(tabState.getState(1).annotationCount, testValue);
+      await promise2;
+      assert.calledTwice(getStub);
+      assert.strictEqual(tabState.getState(2).annotationCount, testValue);
+    });
+
+    it('sets the annotation count to zero if badge request is rejected', async () => {
+      getStub.rejects('some error condition');
+
+      const tabState = new TabState({
+        1: { state: states.ACTIVE },
+      });
+
+      const promise = tabState.updateAnnotationCount(1, 'foobar.com');
+      clock.tick(3010);
+      await promise;
+      assert.strictEqual(tabState.getState(1).annotationCount, 0);
     });
   });
 });


### PR DESCRIPTION
The `tab.onUpdated` event is fired many times during the loading of a page. The larger the document the more times the event is triggered.

By moving the method that request badges to a place that is only reached when the page is fully loaded, we avoid unnecessary fetch request to the badge end point.