### PR TITLE
Reset the badge count to 0 in case of badge fetch failures, not cancellation

### DIFF
--- a/src/background/errors.js
+++ b/src/background/errors.js
@@ -12,6 +12,8 @@ export class BlockedSiteError extends ExtensionError {}
 
 export class AlreadyInjectedError extends ExtensionError {}
 
+export class RequestCanceledError extends Error {}
+
 /**
  * Returns true if `err` is a recognized 'expected' error.
  */

--- a/tests/background/uri-info-test.js
+++ b/tests/background/uri-info-test.js
@@ -104,7 +104,7 @@ describe('background/uri-info', () => {
       }
     );
 
-    it('throws an error if the reponse is not valid JSON', () => {
+    it('throws an error if the response is not valid JSON', () => {
       fetchStub.resolves(
         new Response('this is not valid json', {
           status: 200,


### PR DESCRIPTION
If errors arise during the fetching of badge requests it reset the count to 0.
    
In case of cancellations, do not reset the count to 0.