### PR TITLE
Skip badge request if URL is the cache

### DIFF
--- a/src/background/errors.js
+++ b/src/background/errors.js
@@ -14,6 +14,8 @@ export class AlreadyInjectedError extends ExtensionError {}
 
 export class RequestCanceledError extends Error {}
 
+export class BadgeUriError extends Error {}
+
 /**
  * Returns true if `err` is a recognized 'expected' error.
  */

--- a/tests/background/tab-state-test.js
+++ b/tests/background/tab-state-test.js
@@ -133,16 +133,20 @@ describe('TabState', () => {
 
   describe('#updateAnnotationCount', () => {
     let clock;
-    let getStub;
+    let fetchAnnotationCountStub;
+    let uriForBadgeRequestStub;
     const INITIAL_WAIT_MS = 1000;
     const MAX_WAIT_MS = 3000;
+    const CACHE_EXPIRATION_MS = 3000;
 
     beforeEach(() => {
       clock = sinon.useFakeTimers();
-      getStub = sinon.stub();
+      fetchAnnotationCountStub = sinon.stub();
+      uriForBadgeRequestStub = sinon.stub().returnsArg(0);
       $imports.$mock({
         './uri-info': {
-          getAnnotationCount: getStub,
+          fetchAnnotationCount: fetchAnnotationCountStub,
+          uriForBadgeRequest: uriForBadgeRequestStub,
         },
       });
     });
@@ -152,29 +156,121 @@ describe('TabState', () => {
       clock.restore();
     });
 
-    it(`queries the service and sets the annotation count after waiting for a period of ${INITIAL_WAIT_MS}ms`, async () => {
+    it("doesn't query the service for invalid URLs", async () => {
       const testValue = 42;
-      getStub.resolves(testValue);
+      fetchAnnotationCountStub.resolves(testValue);
+      uriForBadgeRequestStub.throws('any error');
       const tabState = new TabState({ 1: { state: states.ACTIVE } });
 
-      const promise = tabState.updateAnnotationCount(1, 'foobar.com');
+      const promise = tabState.updateAnnotationCount(1, 'invalidOrblocked');
       clock.tick(INITIAL_WAIT_MS);
 
       await promise;
-      assert.called(getStub);
+      assert.notCalled(fetchAnnotationCountStub);
+      assert.equal(tabState.getState(1).annotationCount, 0);
+    });
+
+    it('updates the annotationCount (immediately) if previous URL query is still in the cache', async () => {
+      const firstValue = 33;
+      const secondValue = 41;
+      fetchAnnotationCountStub.onCall(0).resolves(firstValue);
+      fetchAnnotationCountStub.onCall(1).resolves(secondValue);
+      const tabState = new TabState({
+        1: { state: states.ACTIVE },
+        2: { state: states.ACTIVE },
+      });
+
+      const promise1 = tabState.updateAnnotationCount(1, 'http://foobar.com');
+      clock.tick(INITIAL_WAIT_MS);
+
+      await promise1;
+      assert.calledOnce(fetchAnnotationCountStub);
+      assert.equal(tabState.getState(1).annotationCount, firstValue);
+
+      // During the second request the URL is still in the cache
+      // It updates the immediately (no wait), and for different tabs
+      const promise2 = tabState.updateAnnotationCount(1, 'http://foobar.com');
+      const promise3 = tabState.updateAnnotationCount(2, 'http://foobar.com');
+
+      await promise2;
+      await promise3;
+      assert.calledOnce(fetchAnnotationCountStub);
+      assert.equal(tabState.getState(1).annotationCount, firstValue);
+      assert.equal(tabState.getState(2).annotationCount, firstValue);
+
+      // During the third request the URL is not in the cache anymore
+      clock.tick(CACHE_EXPIRATION_MS);
+      const promise4 = tabState.updateAnnotationCount(1, 'http://foobar.com');
+      clock.tick(INITIAL_WAIT_MS);
+
+      await promise4;
+      assert.calledTwice(fetchAnnotationCountStub);
+      assert.equal(tabState.getState(1).annotationCount, secondValue);
+      assert.equal(tabState.getState(2).annotationCount, firstValue);
+    });
+
+    it('updates the annotationCount (after waiting period) if previous URL query is still in the cache', async () => {
+      const testValue = 33;
+      const WAIT_FETCH = 500; // Takes 2000ms to return a response
+      fetchAnnotationCountStub.returns(
+        new Promise(resolve => setTimeout(() => resolve(testValue), WAIT_FETCH))
+      );
+
+      const tabState = new TabState({
+        1: { state: states.ACTIVE },
+        2: { state: states.ACTIVE },
+      });
+
+      // This is the scenario:
+      //                         wait   fetch
+      // Request from tab 1   |--------||---|
+      // Request from tab 2        |--------|
+
+      const promise1 = tabState.updateAnnotationCount(1, 'http://foobar.com');
+      clock.tick(INITIAL_WAIT_MS);
+
+      assert.calledOnce(fetchAnnotationCountStub);
+      assert.equal(tabState.getState(1).annotationCount, 0);
+
+      // The second request comes from another tab, hence it is not cancelled.
+      // At this point the cache is empty
+      const promise2 = tabState.updateAnnotationCount(2, 'http://foobar.com');
+      clock.tick(WAIT_FETCH);
+      await promise1;
+      assert.equal(tabState.getState(1).annotationCount, testValue);
+      assert.equal(tabState.getState(2).annotationCount, 0);
+
+      // By the time the request from the second tab finish the waiting period,
+      // the cache has the value and it skips the fetching of the badge count.
+      clock.tick(WAIT_FETCH);
+      await promise2;
+      assert.calledOnce(fetchAnnotationCountStub);
+      assert.equal(tabState.getState(2).annotationCount, testValue);
+    });
+
+    it(`queries the service and sets the annotation count after waiting for a period of ${INITIAL_WAIT_MS}ms`, async () => {
+      const testValue = 42;
+      fetchAnnotationCountStub.resolves(testValue);
+      const tabState = new TabState({ 1: { state: states.ACTIVE } });
+
+      const promise = tabState.updateAnnotationCount(1, 'http://foobar.com');
+      clock.tick(INITIAL_WAIT_MS);
+
+      await promise;
+      assert.called(fetchAnnotationCountStub);
       assert.equal(tabState.getState(1).annotationCount, testValue);
     });
 
     it(`resolves last request after a maximum of ${MAX_WAIT_MS}ms when several requests are made in succession to the service`, async () => {
       const testValue = 42;
-      getStub.resolves(testValue);
+      fetchAnnotationCountStub.resolves(testValue);
       const tabState = new TabState({ 1: { state: states.ACTIVE } });
 
-      // Simulate several URL changes in rapid succession.
+      // Simulate several URL changes in rapid succession
       const start = Date.now();
       let done;
       for (let i = 0; i < 10; i++) {
-        done = tabState.updateAnnotationCount(1, 'foobar.com');
+        done = tabState.updateAnnotationCount(1, 'http://foobar.com');
       }
       await clock.runToLastAsync();
       await done;
@@ -182,26 +278,26 @@ describe('TabState', () => {
 
       // all pending requests are canceled except the last one which is resolved in no more than MAX_WAIT_MS
       assert.equal(end - start, MAX_WAIT_MS);
-      assert.calledOnce(getStub);
+      assert.calledOnce(fetchAnnotationCountStub);
       assert.equal(tabState.getState(1).annotationCount, testValue);
     });
 
     it('cancels the first query (during waiting stage) when the service is called two consecutive times for the same tab', async () => {
       const initialValue = 33;
       const testValue = 42;
-      getStub.resolves(testValue);
+      fetchAnnotationCountStub.resolves(testValue);
       const tabState = new TabState({
         1: { state: states.ACTIVE, annotationCount: initialValue },
       });
 
-      const promise1 = tabState.updateAnnotationCount(1, 'foobar.com');
-      const promise2 = tabState.updateAnnotationCount(1, 'foobar.com'); // promise 1 is still waiting when promise2 is called
+      const promise1 = tabState.updateAnnotationCount(1, 'http://foobar.com');
+      const promise2 = tabState.updateAnnotationCount(1, 'http://foobar.com'); // promise 1 is still waiting when promise2 is called
       assert.equal(tabState.getState(1).annotationCount, initialValue);
       clock.tick(MAX_WAIT_MS);
 
       await promise1;
       await promise2;
-      assert.calledOnce(getStub);
+      assert.calledOnce(fetchAnnotationCountStub);
       assert.equal(tabState.getState(1).annotationCount, testValue);
     });
 
@@ -210,7 +306,7 @@ describe('TabState', () => {
       const testValue = 42;
 
       const WAIT_FETCH = 2000; // Takes 2000ms to return a response
-      getStub.returns(
+      fetchAnnotationCountStub.returns(
         new Promise(resolve => setTimeout(() => resolve(testValue), WAIT_FETCH))
       );
 
@@ -218,46 +314,46 @@ describe('TabState', () => {
         1: { state: states.ACTIVE, annotationCount: initialValue },
       });
 
-      const promise1 = tabState.updateAnnotationCount(1, 'foobar.com');
+      const promise1 = tabState.updateAnnotationCount(1, 'http://foobar.com');
       clock.tick(INITIAL_WAIT_MS); // promise1 finished waiting and it is fetching the request
-      const promise2 = tabState.updateAnnotationCount(1, 'foobar.com');
+      const promise2 = tabState.updateAnnotationCount(1, 'http://foobar.com');
       assert.equal(tabState.getState(1).annotationCount, initialValue);
       clock.tick(MAX_WAIT_MS + WAIT_FETCH);
 
       await promise1;
       await promise2;
-      assert.calledTwice(getStub); // request is not cancelled
+      assert.calledTwice(fetchAnnotationCountStub); // request is not cancelled
       assert.equal(tabState.getState(1).annotationCount, testValue);
     });
 
     it('resolves two concurrent requests if they are made for different tabs', async () => {
       const testValue = 42;
-      getStub.resolves(testValue);
+      fetchAnnotationCountStub.resolves(testValue);
 
       const tabState = new TabState({
         1: { state: states.ACTIVE },
         2: { state: states.ACTIVE },
       });
 
-      const promise1 = tabState.updateAnnotationCount(1, 'foobar.com');
-      const promise2 = tabState.updateAnnotationCount(2, 'foobar.com');
+      const promise1 = tabState.updateAnnotationCount(1, 'http://foobar.com');
+      const promise2 = tabState.updateAnnotationCount(2, 'http://foobar.com');
       clock.tick(INITIAL_WAIT_MS);
 
       await promise1;
       await promise2;
-      assert.calledTwice(getStub);
+      assert.calledTwice(fetchAnnotationCountStub);
       assert.equal(tabState.getState(1).annotationCount, testValue);
       assert.equal(tabState.getState(2).annotationCount, testValue);
     });
 
     it('sets the annotation count to zero if badge request is rejected', async () => {
-      getStub.rejects('some error condition');
+      fetchAnnotationCountStub.rejects('some error condition');
 
       const tabState = new TabState({
         1: { state: states.ACTIVE, annotationCount: 33 },
       });
 
-      const promise = tabState.updateAnnotationCount(1, 'foobar.com');
+      const promise = tabState.updateAnnotationCount(1, 'http://foobar.com');
       clock.tick(MAX_WAIT_MS);
 
       await promise;


### PR DESCRIPTION
In order to further reduce the number of badge requests we implement a cache or badge request results. This cache is temporal and it contains key-value pairs of URLs and annotation counts.

* every entry in the cache (URL and annotation count pair) is added only after successful fetching of the annotation count.
* fragment is removed from the URL
* every entry in the cache  is stored for X amount of time. After that time the entry is deleted. This is to allow updating the annotation count in case of reloading of the document in the tab, after X amount of time. 

Currently, X is set to 3000 ms.

I feel this could lead to minor frustrations for users that are reloading the document in less than X amount of time to see changes in the annotation count.