### PR TITLE
Enable type checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ dist/%.zip dist/%.xpi: extension
 .PHONY: lint
 lint:
 	$(ESLINT) .
+	yarn typecheck
 
 .PHONY: checkformatting
 checkformatting:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
+    "@types/chrome": "^0.0.126",
     "babel-plugin-mockable-imports": "^1.7.0",
     "babelify": "^10.0.0",
     "browserify": "^16.5.2",
@@ -39,11 +40,13 @@
     "query-string": "^3.0.1",
     "raven-js": "^3.27.2",
     "sinon": "^9.2.0",
+    "typescript": "^4.0.5",
     "watchify": "^3.11.1",
     "web-ext": "^5.3.0"
   },
   "scripts": {
-    "test": "karma start tests/karma.config.js --single-run"
+    "test": "karma start tests/karma.config.js --single-run",
+    "typecheck": "tsc --build src/tsconfig.json"
   },
   "dependencies": {}
 }

--- a/src/background/browser-name.js
+++ b/src/background/browser-name.js
@@ -4,6 +4,7 @@
  * @return {'chrome'|'firefox'}
  */
 export default function browserName() {
+  // @ts-expect-error - `browser` is missing from types
   if (window.browser) {
     return 'firefox';
   } else {

--- a/src/background/errors.js
+++ b/src/background/errors.js
@@ -1,42 +1,42 @@
 import * as raven from './raven';
 
 export function ExtensionError(message) {
-  Error.apply(this, arguments);
+  Error.apply(this, [message]);
   this.message = message;
 }
 
 ExtensionError.prototype = Object.create(Error.prototype);
 
 export function LocalFileError(message) {
-  Error.apply(this, arguments);
+  Error.apply(this, [message]);
   this.message = message;
 }
 
 LocalFileError.prototype = Object.create(ExtensionError.prototype);
 
 export function NoFileAccessError(message) {
-  Error.apply(this, arguments);
+  Error.apply(this, [message]);
   this.message = message;
 }
 
 NoFileAccessError.prototype = Object.create(ExtensionError.prototype);
 
 export function RestrictedProtocolError(message) {
-  Error.apply(this, arguments);
+  Error.apply(this, [message]);
   this.message = message;
 }
 
 RestrictedProtocolError.prototype = Object.create(ExtensionError.prototype);
 
 export function BlockedSiteError(message) {
-  Error.apply(this, arguments);
+  Error.apply(this, [message]);
   this.message = message;
 }
 
 BlockedSiteError.prototype = Object.create(ExtensionError.prototype);
 
 export function AlreadyInjectedError(message) {
-  Error.apply(this, arguments);
+  Error.apply(this, [message]);
   this.message = message;
 }
 

--- a/src/background/help-page.js
+++ b/src/background/help-page.js
@@ -47,7 +47,7 @@ export default function HelpPage(chromeTabs, extensionURL, browserName_) {
    *
    * @param {string} helpSection - ID of a <section> within the help page.
    * @param {chrome.tabs.Tab} tab - The tab where the error occurred.
-   * @param {Error} error - The error which prompted the help page.
+   * @param {Error} [error] - The error which prompted the help page.
    */
   function showHelpPage(helpSection, tab, error) {
     let params = '';

--- a/src/background/help-page.js
+++ b/src/background/help-page.js
@@ -46,7 +46,7 @@ export default function HelpPage(chromeTabs, extensionURL, browserName_) {
    * Open a tab displaying the help page.
    *
    * @param {string} helpSection - ID of a <section> within the help page.
-   * @param {tabs.Tab} tab - The tab where the error occurred.
+   * @param {chrome.tabs.Tab} tab - The tab where the error occurred.
    * @param {Error} error - The error which prompted the help page.
    */
   function showHelpPage(helpSection, tab, error) {

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,6 +1,8 @@
 import * as raven from './raven';
 
+// @ts-expect-error - `EXTENSION_CONFIG` is missing from types
 if (window.EXTENSION_CONFIG.raven) {
+  // @ts-expect-error - `EXTENSION_CONFIG` is missing from types
   raven.init(window.EXTENSION_CONFIG.raven);
 }
 

--- a/src/background/install.js
+++ b/src/background/install.js
@@ -16,9 +16,10 @@ export function init() {
     },
   });
 
-  browserExtension.listen(window);
+  browserExtension.listen();
 }
 
+// @ts-expect-error - `isFakeChrome` is missing from types.
 if (!chrome.isFakeChrome) {
   init();
 }

--- a/src/background/raven.js
+++ b/src/background/raven.js
@@ -6,7 +6,7 @@
  * version to be provided via the app's settings object.
  */
 
-import Raven from 'raven-js';
+import * as Raven from 'raven-js';
 
 /**
  * Returns the input URL if it is an HTTP URL or the filename part of the URL
@@ -69,7 +69,7 @@ export function init(config) {
 /**
  * Report an error to Sentry.
  *
- * @param {Error} error - An error object describing what went wrong
+ * @param {Object} error - An error object describing what went wrong
  * @param {string} when - A string describing the context in which
  *                        the error occurred.
  * @param {Object} [context] - A JSON-serializable object containing additional

--- a/src/background/settings.js
+++ b/src/background/settings.js
@@ -14,4 +14,4 @@ function normalizeSettings(settings) {
 /**
  * Returns the configuration object for the Chrome extension
  */
-export default normalizeSettings(window.EXTENSION_CONFIG);
+export default normalizeSettings(/** @type {any} */ (window).EXTENSION_CONFIG);

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -81,7 +81,7 @@ export default function SidebarInjector(chromeTabs, dependencies) {
   /**
    * Injects the Hypothesis sidebar into the tab provided.
    *
-   * @param {Tab} tab - A tab object representing the tab to insert the sidebar
+   * @param {chrome.tabs.Tab} tab - A tab object representing the tab to insert the sidebar
    *        into.
    * @param {Object?} config - An object containing configuration info that
    *        is passed to the app when it loads.

--- a/src/background/tab-state.js
+++ b/src/background/tab-state.js
@@ -143,7 +143,7 @@ export default function TabState(initialState, onchange) {
    * Request the current annotation count for the tab's URL
    *
    * @method
-   * @param {integer} tabId The id of the tab.
+   * @param {number} tabId The id of the tab.
    * @param {string} tabUrl The URL of the tab.
    */
   this.updateAnnotationCount = function (tabId, tabUrl) {

--- a/src/background/util.js
+++ b/src/background/util.js
@@ -27,6 +27,7 @@ export function promisify(fn) {
     const args = [].slice.call(arguments);
     const result = new Promise(function (resolve, reject) {
       fn.apply(
+        // @ts-ignore - `this` is implicitly `any`
         this,
         args.concat(function (result) {
           const lastError = getLastError();

--- a/src/help/index.js
+++ b/src/help/index.js
@@ -26,6 +26,8 @@ chrome.runtime.getPlatformInfo(function (info) {
 
 const query = parseQuery(window.location.search);
 if (query.message) {
-  const errorTextEl = document.querySelector('.js-error-message');
+  const errorTextEl = /** @type {HTMLElement} */ (document.querySelector(
+    '.js-error-message'
+  ));
   errorTextEl.textContent = query.message;
 }

--- a/src/help/index.js
+++ b/src/help/index.js
@@ -16,8 +16,10 @@ function parseQuery(query) {
 
 // Detect the current OS and show approprite help.
 chrome.runtime.getPlatformInfo(function (info) {
-  const opts = document.querySelectorAll('[data-extension-path]');
-  [].forEach.call(opts, function (opt) {
+  const opts = /** @type {NodeListOf<HTMLElement>} */ (document.querySelectorAll(
+    '[data-extension-path]'
+  ));
+  opts.forEach(opt => {
     if (opt.dataset.extensionPath !== info.os) {
       opt.hidden = true;
     }

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,8 +1,15 @@
 'use strict';
 
+/**
+ * Return the checkbox that toggles whether badge requests are sent.
+ */
+function badgeCheckbox() {
+  return /** @type {HTMLInputElement} */ (document.getElementById('badge'));
+}
+
 function saveOptions() {
   chrome.storage.sync.set({
-    badge: document.getElementById('badge').checked,
+    badge: badgeCheckbox().checked,
   });
 }
 
@@ -12,10 +19,10 @@ function loadOptions() {
       badge: true,
     },
     function (items) {
-      document.getElementById('badge').checked = items.badge;
+      badgeCheckbox().checked = items.badge;
     }
   );
 }
 
 document.addEventListener('DOMContentLoaded', loadOptions);
-document.getElementById('badge').addEventListener('click', saveOptions);
+badgeCheckbox().addEventListener('click', saveOptions);

--- a/src/pdfjs-init.js
+++ b/src/pdfjs-init.js
@@ -16,7 +16,9 @@ document.head.appendChild(configScript);
 // Listen for `webviewerloaded` event to configure the viewer after its files
 // have been loaded but before it is initialized.
 document.addEventListener('webviewerloaded', () => {
+  // @ts-expect-error - PDFViewerApplicationOptions is missing from types.
   const appOptions = window.PDFViewerApplicationOptions;
+  // @ts-expect-error - PDFViewerApplication is missing from types.
   const app = window.PDFViewerApplication;
 
   // Ensure that PDF.js viewer events such as "documentloaded" are dispatched

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -7,7 +7,8 @@
     "jsxFactory": "createElement",
     "module": "commonjs",
     "noEmit": true,
-    "strictNullChecks": true,
+    "strict": true,
+    "noImplicitAny": false,
     "target": "ES2020"
   },
   "include": [

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,8 +3,6 @@
     "allowJs": true,
     "checkJs": true,
     "lib": ["es2018", "dom"],
-    "jsx": "react",
-    "jsxFactory": "createElement",
     "module": "commonjs",
     "noEmit": true,
     "strict": true,

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "lib": ["es2018", "dom"],
+    "jsx": "react",
+    "jsxFactory": "createElement",
+    "module": "commonjs",
+    "noEmit": true,
+    "strictNullChecks": true,
+    "target": "ES2020"
+  },
+  "include": [
+    "**/*.js"
+  ],
+  "exclude": [
+    "vendor/"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,6 +960,31 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/chrome@^0.0.126":
+  version "0.0.126"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.126.tgz#f9f3436712f0c7c12ea9798abc9b95575ad7b23a"
+  integrity sha512-191z7uoyfbGU+z7/m45j9XbWugWqVHVPMM4hJV5cZ+3YzGCT9wFjMUHO3Wr3Xvo8aVodvRNu28u7lvEaAnfbzg==
+  dependencies:
+    "@types/filesystem" "*"
+    "@types/har-format" "*"
+
+"@types/filesystem@*":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.29.tgz#ee3748eb5be140dcf980c3bd35f11aec5f7a3748"
+  integrity sha512-85/1KfRedmfPGsbK8YzeaQUyV1FQAvMPMTuWFQ5EkLd2w7szhNO96bk3Rh/SKmOfd9co2rCLf0Voy4o7ECBOvw==
+  dependencies:
+    "@types/filewriter" "*"
+
+"@types/filewriter@*":
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.28.tgz#c054e8af4d9dd75db4e63abc76f885168714d4b3"
+  integrity sha1-wFTor02d11205jq8dviFFocU1LM=
+
+"@types/har-format@*":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.5.tgz#4f6648814d0fdcb6a510e3364a9db439a753c4b1"
+  integrity sha512-IG8AE1m2pWtPqQ7wXhFhy6Q59bwwnLwO36v5Rit2FrbXCIp8Sk8E2PfUCreyrdo17STwFSKDAkitVuVYbpEHvQ==
+
 "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -7260,6 +7285,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 ua-parser-js@0.7.22:
   version "0.7.22"


### PR DESCRIPTION
This PR adds type checking to the browser-extension project in a similar manner to how we have it set up for the client and lms projects. It also fixes the small number of existing type checking errors.

This will help catch mistakes in JSDoc documentation, incorrect API usage etc.

To run type checking locally use `yarn typecheck` or `make lint`. If you have an editor integration set up already that should also flag errors.