### PR TITLE
Improve JSDoc for various classes and types in the background page

### DIFF
--- a/src/background/browser-action.js
+++ b/src/background/browser-action.js
@@ -78,11 +78,12 @@ export default function BrowserAction(chromeBrowserAction) {
 
     // display the annotation count on the badge
     if (state.state !== 'errored' && state.annotationCount) {
-      let countLabel;
       let totalString = state.annotationCount.toString();
       if (state.annotationCount > 999) {
         totalString = '999+';
       }
+
+      let countLabel;
       if (state.annotationCount === 1) {
         countLabel = _("There's 1 annotation on this page");
       } else {
@@ -90,6 +91,7 @@ export default function BrowserAction(chromeBrowserAction) {
           'There are ' + totalString + ' annotations on this page'
         );
       }
+
       title = countLabel;
       badgeText = totalString;
     }

--- a/src/background/browser-action.js
+++ b/src/background/browser-action.js
@@ -1,19 +1,16 @@
 import settings from './settings';
-import TabState from './tab-state';
-
-// Cache the tab state constants.
-const states = TabState.states;
 
 // Each button state has two icons one for normal resolution (19) and one
 // for hi-res screens (38).
-const icons = {};
-icons[states.ACTIVE] = {
-  19: 'images/browser-icon-active.png',
-  38: 'images/browser-icon-active@2x.png',
-};
-icons[states.INACTIVE] = {
-  19: 'images/browser-icon-inactive.png',
-  38: 'images/browser-icon-inactive@2x.png',
+const icons = {
+  active: {
+    19: 'images/browser-icon-active.png',
+    38: 'images/browser-icon-active@2x.png',
+  },
+  inactive: {
+    19: 'images/browser-icon-inactive.png',
+    38: 'images/browser-icon-inactive@2x.png',
+  },
 };
 
 // themes to apply to the toolbar icon badge depending on the type of
@@ -34,12 +31,15 @@ function _(str) {
   return str;
 }
 
-/* Controls the display of the browser action button setting the icon, title
+/**
+ * Controls the display of the browser action button setting the icon, title
  * and badges depending on the current state of the tab.
  *
  * BrowserAction is responsible for mapping the logical H state of
  * a tab (whether the extension is active, annotation count) to
  * the badge state.
+ *
+ * @param {chrome.browserAction} chromeBrowserAction
  */
 export default function BrowserAction(chromeBrowserAction) {
   const buildType = settings.buildType;
@@ -51,16 +51,16 @@ export default function BrowserAction(chromeBrowserAction) {
    * @param state - The H state of a tab. See the 'tab-state' module.
    */
   this.update = function (tabId, state) {
-    let activeIcon = icons[states.INACTIVE];
+    let activeIcon = icons.inactive;
     let title = '';
     let badgeText = '';
 
-    if (state.state === states.ACTIVE) {
-      activeIcon = icons[states.ACTIVE];
+    if (state.state === 'active') {
+      activeIcon = icons.active;
       title = 'Hypothesis is active';
-    } else if (state.state === states.INACTIVE) {
+    } else if (state.state === 'inactive') {
       title = 'Hypothesis is inactive';
-    } else if (state.state === states.ERRORED) {
+    } else if (state.state === 'errored') {
       title = 'Hypothesis failed to load';
       badgeText = '!';
     } else {
@@ -68,7 +68,7 @@ export default function BrowserAction(chromeBrowserAction) {
     }
 
     // display the annotation count on the badge
-    if (state.state !== states.ERRORED && state.annotationCount) {
+    if (state.state !== 'errored' && state.annotationCount) {
       let countLabel;
       let totalString = state.annotationCount.toString();
       if (state.annotationCount > 999) {

--- a/src/background/browser-action.js
+++ b/src/background/browser-action.js
@@ -1,5 +1,9 @@
 import settings from './settings';
 
+/**
+ * @typedef {import('./tab-state').State} TabState
+ */
+
 // Each button state has two icons one for normal resolution (19) and one
 // for hi-res screens (38).
 const icons = {
@@ -48,23 +52,28 @@ export default function BrowserAction(chromeBrowserAction) {
    * Updates the state of the browser action to reflect the logical
    * H state of a tab.
    *
-   * @param state - The H state of a tab. See the 'tab-state' module.
+   * @param {number} tabId
+   * @param {TabState} state
    */
   this.update = function (tabId, state) {
-    let activeIcon = icons.inactive;
-    let title = '';
+    let activeIcon;
+    let title;
     let badgeText = '';
 
-    if (state.state === 'active') {
-      activeIcon = icons.active;
-      title = 'Hypothesis is active';
-    } else if (state.state === 'inactive') {
-      title = 'Hypothesis is inactive';
-    } else if (state.state === 'errored') {
-      title = 'Hypothesis failed to load';
-      badgeText = '!';
-    } else {
-      throw new Error('Unknown tab state');
+    switch (state.state) {
+      case 'active':
+        activeIcon = icons.active;
+        title = 'Hypothesis is active';
+        break;
+      case 'inactive':
+        activeIcon = icons.inactive;
+        title = 'Hypothesis is inactive';
+        break;
+      case 'errored':
+        activeIcon = icons.inactive;
+        title = 'Hypothesis failed to load';
+        badgeText = '!';
+        break;
     }
 
     // display the annotation count on the badge

--- a/src/background/detect-content-type.js
+++ b/src/background/detect-content-type.js
@@ -9,10 +9,10 @@
  * In future this could also be extended to support extraction of the URLs
  * of content in embedded viewers where that differs from the tab's
  * main URL.
+ *
+ * @param {Document} document_ - Test seam
  */
-export default function detectContentType(document_) {
-  document_ = document_ || document;
-
+export default function detectContentType(document_ = document) {
   function detectChromePDFViewer() {
     // When viewing a PDF in Chrome, the viewer consists of a top-level
     // document with an <embed> tag, which in turn instantiates an inner HTML

--- a/src/background/hypothesis-chrome-extension.js
+++ b/src/background/hypothesis-chrome-extension.js
@@ -113,8 +113,9 @@ export default function HypothesisChromeExtension({
     state.load(store.all());
     chromeTabs.query({}, function (tabs) {
       tabs.forEach(function (tab) {
-        const id = /** @type {number} */ (tab.id);
-        onTabStateChange(id, state.getState(id));
+        if (tab.id) {
+          onTabStateChange(tab.id, state.getState(tab.id));
+        }
       });
     });
   }

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -48,24 +48,25 @@ function extractContentScriptResult(result) {
   }
 }
 
-/* The SidebarInjector is used to deploy and remove the Hypothesis sidebar
+/**
+ * The SidebarInjector is used to deploy and remove the Hypothesis sidebar
  * from tabs. It also deals with loading PDF documents into the PDF.js viewer
  * when applicable.
  *
- * chromeTabs - An instance of chrome.tabs.
- * dependencies - An object with additional helper methods.
- *   isAllowedFileSchemeAccess: A function that returns true if the user
+ * @param {chrome.tabs} chromeTabs
+ * @param {Object} services
+ * @param {(cb: (allowed: boolean) => void) => void} services.isAllowedFileSchemeAccess -
+ *   A function that returns true if the user
  *   can access resources over the file:// protocol. See:
  *   https://developer.chrome.com/extensions/extension#method-isAllowedFileSchemeAccess
- *   extensionURL: A function that receives a path and returns an absolute
+ * @param {(path: string) => string} services.extensionURL -
+ *   A function that receives a path and returns an absolute
  *   url. See: https://developer.chrome.com/extensions/extension#method-getURL
  */
-export default function SidebarInjector(chromeTabs, dependencies) {
-  dependencies = dependencies || {};
-
-  const isAllowedFileSchemeAccess = dependencies.isAllowedFileSchemeAccess;
-  const extensionURL = dependencies.extensionURL;
-
+export default function SidebarInjector(
+  chromeTabs,
+  { isAllowedFileSchemeAccess, extensionURL }
+) {
   const executeScriptFn = util.promisify(chromeTabs.executeScript);
 
   const PDFViewerBaseURL = extensionURL('/pdfjs/web/viewer.html');

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -71,14 +71,6 @@ export default function SidebarInjector(
 
   const PDFViewerBaseURL = extensionURL('/pdfjs/web/viewer.html');
 
-  if (typeof extensionURL !== 'function') {
-    throw new TypeError('extensionURL must be a function');
-  }
-
-  if (typeof isAllowedFileSchemeAccess !== 'function') {
-    throw new TypeError('isAllowedFileSchemeAccess must be a function');
-  }
-
   /**
    * Injects the Hypothesis sidebar into the tab provided.
    *

--- a/src/background/tab-state.js
+++ b/src/background/tab-state.js
@@ -47,12 +47,10 @@ const DEFAULT_STATE = {
  *
  * @param {TabStateMap} initialState - Initial state information for tabs, eg.
  *   from a persistent store.
- * @param {(tabId: number, current: undefined|State) => any} onchange -
+ * @param {(tabId: number, current: undefined|State) => any} [onchange] -
  *   Callback invoked when state for a tab changes
  */
 export default function TabState(initialState, onchange) {
-  const self = this;
-
   /**
    * Current Hypothesis-related state for each tab.
    *
@@ -74,7 +72,7 @@ export default function TabState(initialState, onchange) {
   /** @type {Map<string, number>} */
   const annotationCountCache = new Map();
 
-  this.onchange = onchange || null;
+  this.onchange = onchange;
 
   /**
    * Replaces the H state for all tabs.
@@ -212,8 +210,8 @@ export default function TabState(initialState, onchange) {
       delete currentState[tabId];
     }
 
-    if (self.onchange) {
-      self.onchange(tabId, newState);
+    if (this.onchange) {
+      this.onchange(tabId, newState);
     }
   };
 

--- a/tests/background/browser-action-test.js
+++ b/tests/background/browser-action-test.js
@@ -1,5 +1,4 @@
 import BrowserAction, { $imports } from '../../src/background/browser-action';
-import TabState from '../../src/background/tab-state';
 
 describe('BrowserAction', function () {
   let action;
@@ -30,58 +29,49 @@ describe('BrowserAction', function () {
 
   describe('active state', function () {
     it('sets the active browser icon', function () {
-      action.update(1, { state: TabState.states.ACTIVE });
-      assert.equal(
-        fakeChromeBrowserAction.icon,
-        BrowserAction.icons[TabState.states.ACTIVE]
-      );
+      action.update(1, { state: 'active' });
+      assert.equal(fakeChromeBrowserAction.icon, BrowserAction.icons.active);
     });
 
     it('sets the title of the browser icon', function () {
-      action.update(1, { state: TabState.states.ACTIVE });
+      action.update(1, { state: 'active' });
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis is active');
     });
 
     it('does not set the title if there is badge text showing', function () {
       const state = {
-        state: TabState.states.INACTIVE,
+        state: 'inactive',
         annotationCount: 9,
       };
       action.update(1, state);
       const prevTitle = fakeChromeBrowserAction.title;
-      action.update(1, Object.assign(state, { state: TabState.states.ACTIVE }));
+      action.update(1, Object.assign(state, { state: 'active' }));
       assert.equal(fakeChromeBrowserAction.title, prevTitle);
     });
   });
 
   describe('inactive state', function () {
     it('sets the inactive browser icon and title', function () {
-      action.update(1, { state: TabState.states.INACTIVE });
-      assert.equal(
-        fakeChromeBrowserAction.icon,
-        BrowserAction.icons[TabState.states.INACTIVE]
-      );
+      action.update(1, { state: 'inactive' });
+      assert.equal(fakeChromeBrowserAction.icon, BrowserAction.icons.inactive);
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis is inactive');
     });
   });
 
   describe('error state', function () {
     it('sets the inactive browser icon', function () {
-      action.update(1, { state: TabState.states.ERRORED });
-      assert.equal(
-        fakeChromeBrowserAction.icon,
-        BrowserAction.icons[TabState.states.INACTIVE]
-      );
+      action.update(1, { state: 'errored' });
+      assert.equal(fakeChromeBrowserAction.icon, BrowserAction.icons.inactive);
     });
 
     it('sets the title of the browser icon', function () {
-      action.update(1, { state: TabState.states.ERRORED });
+      action.update(1, { state: 'errored' });
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis failed to load');
     });
 
     it('still sets the title even there is badge text showing', function () {
       action.update(1, {
-        state: TabState.states.ERRORED,
+        state: 'errored',
         annotationCount: 9,
       });
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis failed to load');
@@ -89,7 +79,7 @@ describe('BrowserAction', function () {
 
     it('shows a badge', function () {
       action.update(1, {
-        state: TabState.states.ERRORED,
+        state: 'errored',
       });
       assert.equal(fakeChromeBrowserAction.badgeText, '!');
     });
@@ -98,7 +88,7 @@ describe('BrowserAction', function () {
   describe('annotation counts', function () {
     it('sets the badge text', function () {
       action.update(1, {
-        state: TabState.states.INACTIVE,
+        state: 'inactive',
         annotationCount: 23,
       });
       assert.equal(fakeChromeBrowserAction.badgeText, '23');
@@ -106,7 +96,7 @@ describe('BrowserAction', function () {
 
     it("sets the badge title when there's 1 annotation", function () {
       action.update(1, {
-        state: TabState.states.INACTIVE,
+        state: 'inactive',
         annotationCount: 1,
       });
       assert.equal(
@@ -117,7 +107,7 @@ describe('BrowserAction', function () {
 
     it("sets the badge title when there's >1 annotation", function () {
       action.update(1, {
-        state: TabState.states.INACTIVE,
+        state: 'inactive',
         annotationCount: 23,
       });
       assert.equal(
@@ -128,7 +118,7 @@ describe('BrowserAction', function () {
 
     it('does not set the badge text if there are 0 annotations', function () {
       action.update(1, {
-        state: TabState.states.INACTIVE,
+        state: 'inactive',
         annotationCount: 0,
       });
       assert.equal(fakeChromeBrowserAction.badgeText, '');
@@ -136,7 +126,7 @@ describe('BrowserAction', function () {
 
     it('does not set the badge title if there are 0 annotations', function () {
       action.update(1, {
-        state: TabState.states.INACTIVE,
+        state: 'inactive',
         annotationCount: 0,
       });
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis is inactive');
@@ -144,7 +134,7 @@ describe('BrowserAction', function () {
 
     it("truncates numbers greater than 999 to '999+'", function () {
       action.update(1, {
-        state: TabState.states.INACTIVE,
+        state: 'inactive',
         annotationCount: 1001,
       });
       assert.equal(fakeChromeBrowserAction.badgeText, '999+');
@@ -174,7 +164,7 @@ describe('BrowserAction', function () {
 
     it('sets the text to QA when there are no annotations', function () {
       action.update(1, {
-        state: TabState.states.INACTIVE,
+        state: 'inactive',
         annotationCount: 0,
       });
       assert.equal(fakeChromeBrowserAction.badgeText, 'QA');
@@ -182,7 +172,7 @@ describe('BrowserAction', function () {
 
     it('shows the annotation count when there are annotations', function () {
       action.update(1, {
-        state: TabState.states.INACTIVE,
+        state: 'inactive',
         annotationCount: 3,
       });
       assert.equal(fakeChromeBrowserAction.badgeText, '3');
@@ -190,7 +180,7 @@ describe('BrowserAction', function () {
 
     it('sets the background color', function () {
       action.update(1, {
-        state: TabState.states.INACTIVE,
+        state: 'inactive',
         annotationCount: 0,
       });
       assert.equal(fakeChromeBrowserAction.badgeColor, '#EDA061');

--- a/tests/background/tab-state-test.js
+++ b/tests/background/tab-state-test.js
@@ -1,8 +1,6 @@
 import TabState, { $imports } from '../../src/background/tab-state';
 
 describe('TabState', () => {
-  const states = TabState.states;
-
   let state;
   let onChange;
 
@@ -10,7 +8,7 @@ describe('TabState', () => {
     onChange = sinon.spy();
     state = new TabState(
       {
-        1: { state: states.ACTIVE },
+        1: { state: 'active' },
       },
       onChange
     );
@@ -32,7 +30,7 @@ describe('TabState', () => {
 
   describe('#load', () => {
     it('replaces the current tab states with a new object', () => {
-      state.load({ 2: { state: states.INACTIVE } });
+      state.load({ 2: { state: 'inactive' } });
       // `load` (re)sets all tabs to their default state, which is inactive
       assert.equal(state.isTabActive(1), false);
       assert.equal(state.isTabInactive(2), true);
@@ -47,7 +45,7 @@ describe('TabState', () => {
 
     it('triggers an onchange handler', () => {
       state.activateTab(2);
-      assert.calledWith(onChange, 2, sinon.match({ state: states.ACTIVE }));
+      assert.calledWith(onChange, 2, sinon.match({ state: 'active' }));
     });
   });
 
@@ -59,7 +57,7 @@ describe('TabState', () => {
 
     it('triggers an onchange handler', () => {
       state.deactivateTab(2);
-      assert.calledWith(onChange, 2, sinon.match({ state: states.INACTIVE }));
+      assert.calledWith(onChange, 2, sinon.match({ state: 'inactive' }));
     });
   });
 
@@ -71,7 +69,7 @@ describe('TabState', () => {
 
     it('triggers an onchange handler', () => {
       state.errorTab(2);
-      assert.calledWith(onChange, 2, sinon.match({ state: states.ERRORED }));
+      assert.calledWith(onChange, 2, sinon.match({ state: 'errored' }));
     });
   });
 
@@ -126,7 +124,7 @@ describe('TabState', () => {
     it('clears the error when not errored', () => {
       state.errorTab(1, new Error('Some error'));
       assert.ok(state.getState(1).error instanceof Error);
-      state.setState(1, { state: states.INACTIVE });
+      state.setState(1, { state: 'inactive' });
       assert.notOk(state.getState(1).error);
     });
   });
@@ -160,7 +158,7 @@ describe('TabState', () => {
       const testValue = 42;
       fetchAnnotationCountStub.resolves(testValue);
       uriForBadgeRequestStub.throws('any error');
-      const tabState = new TabState({ 1: { state: states.ACTIVE } });
+      const tabState = new TabState({ 1: { state: 'active' } });
 
       const promise = tabState.updateAnnotationCount(1, 'invalidOrblocked');
       clock.tick(INITIAL_WAIT_MS);
@@ -176,8 +174,8 @@ describe('TabState', () => {
       fetchAnnotationCountStub.onCall(0).resolves(firstValue);
       fetchAnnotationCountStub.onCall(1).resolves(secondValue);
       const tabState = new TabState({
-        1: { state: states.ACTIVE },
-        2: { state: states.ACTIVE },
+        1: { state: 'active' },
+        2: { state: 'active' },
       });
 
       const promise1 = tabState.updateAnnotationCount(1, 'http://foobar.com');
@@ -217,8 +215,8 @@ describe('TabState', () => {
       );
 
       const tabState = new TabState({
-        1: { state: states.ACTIVE },
-        2: { state: states.ACTIVE },
+        1: { state: 'active' },
+        2: { state: 'active' },
       });
 
       // This is the scenario:
@@ -251,7 +249,7 @@ describe('TabState', () => {
     it(`queries the service and sets the annotation count after waiting for a period of ${INITIAL_WAIT_MS}ms`, async () => {
       const testValue = 42;
       fetchAnnotationCountStub.resolves(testValue);
-      const tabState = new TabState({ 1: { state: states.ACTIVE } });
+      const tabState = new TabState({ 1: { state: 'active' } });
 
       const promise = tabState.updateAnnotationCount(1, 'http://foobar.com');
       clock.tick(INITIAL_WAIT_MS);
@@ -264,7 +262,7 @@ describe('TabState', () => {
     it(`resolves last request after a maximum of ${MAX_WAIT_MS}ms when several requests are made in succession to the service`, async () => {
       const testValue = 42;
       fetchAnnotationCountStub.resolves(testValue);
-      const tabState = new TabState({ 1: { state: states.ACTIVE } });
+      const tabState = new TabState({ 1: { state: 'active' } });
 
       // Simulate several URL changes in rapid succession
       const start = Date.now();
@@ -287,7 +285,7 @@ describe('TabState', () => {
       const testValue = 42;
       fetchAnnotationCountStub.resolves(testValue);
       const tabState = new TabState({
-        1: { state: states.ACTIVE, annotationCount: initialValue },
+        1: { state: 'active', annotationCount: initialValue },
       });
 
       const promise1 = tabState.updateAnnotationCount(1, 'http://foobar.com');
@@ -311,7 +309,7 @@ describe('TabState', () => {
       );
 
       const tabState = new TabState({
-        1: { state: states.ACTIVE, annotationCount: initialValue },
+        1: { state: 'active', annotationCount: initialValue },
       });
 
       const promise1 = tabState.updateAnnotationCount(1, 'http://foobar.com');
@@ -331,8 +329,8 @@ describe('TabState', () => {
       fetchAnnotationCountStub.resolves(testValue);
 
       const tabState = new TabState({
-        1: { state: states.ACTIVE },
-        2: { state: states.ACTIVE },
+        1: { state: 'active' },
+        2: { state: 'active' },
       });
 
       const promise1 = tabState.updateAnnotationCount(1, 'http://foobar.com');
@@ -350,7 +348,7 @@ describe('TabState', () => {
       fetchAnnotationCountStub.rejects('some error condition');
 
       const tabState = new TabState({
-        1: { state: states.ACTIVE, annotationCount: 33 },
+        1: { state: 'active', annotationCount: 33 },
       });
 
       const promise = tabState.updateAnnotationCount(1, 'http://foobar.com');


### PR DESCRIPTION
Following on from https://github.com/hypothesis/browser-extension/pull/428 this PR fixes issues with and improves the existing JSDoc documentation:

- Fix several JSDoc comments that not start with the correct `/**` text so they are actually parsed as JSDoc
- Convert informal parameter documentation into `@param` so TypeScript can check usage
- Introduce a `@typedef` for the state of each tab so that TS can check usage.
- With the addition of the above typedef, TS can now check that the `state` property (active, inactive, errored) is set to the correct values, so this removes the need for the `states` enum in `tab-state.js`. Since this enum doesn't really have any value any more, I replaced uses of it with equivalent string literals
- Add JSDoc documentation to various methods

In the process TS flagged a couple of places where we assume tabs have an ID and apparently that is not guaranteed (see https://developer.chrome.com/extensions/tabs#type-Tab). I added a check for the one place where we might encounter a tab without an ID.