### PR TITLE
Load to memory only information about the current tabs

### DIFF
--- a/src/background/hypothesis-chrome-extension.js
+++ b/src/background/hypothesis-chrome-extension.js
@@ -109,21 +109,21 @@ export default function HypothesisChromeExtension({
   };
 
   function restoreSavedTabState() {
-    store.reload();
-    state.load(store.all());
     chromeTabs.query({}, function (tabs) {
-      tabs.forEach(function (tab) {
-        if (tab.id) {
-          onTabStateChange(tab.id, state.getState(tab.id));
-        }
+      const tabIds = tabs
+        .filter(tab => tab.id !== undefined)
+        .map(({ id }) => /** @type {number} */ (id));
+      store.reload(tabIds);
+      state.load(store.all());
+      tabIds.forEach(tabId => {
+        onTabStateChange(tabId, state.getState(tabId));
       });
     });
   }
 
   /**
-   *
    * @param {number} tabId
-   * @param {import('./tab-state').State|undefined} current
+   * @param {import('./tab-state').State | undefined} current
    */
   function onTabStateChange(tabId, current) {
     if (current) {

--- a/src/background/tab-store.js
+++ b/src/background/tab-store.js
@@ -36,16 +36,19 @@ export default function TabStore(storage) {
     return local;
   };
 
-  this.reload = function () {
+  /** @param {number[]} tabIds */
+  this.reload = tabIds => {
     try {
       local = {};
       const loaded = JSON.parse(storage.getItem(key));
-      Object.keys(loaded).forEach(key => (local[key] = loaded[key]));
-    } catch (e) {
-      local = null;
+      tabIds.forEach(tabId => {
+        const state = loaded[tabId];
+        if (state) {
+          local[tabId] = state;
+        }
+      });
+    } catch {
+      local = {};
     }
-    local = local || {};
   };
-
-  this.reload();
 }


### PR DESCRIPTION
The storage is accumulating information from very old tabs. This is becuase when the extension is restarted it loads all the information in the storage.

This change will enable to load only the information about the current tabs.