### PR TITLE
Remove support for old format in the localStorage

### DIFF
--- a/src/background/tab-store.js
+++ b/src/background/tab-store.js
@@ -40,16 +40,7 @@ export default function TabStore(storage) {
     try {
       local = {};
       const loaded = JSON.parse(storage.getItem(key));
-      Object.keys(loaded).forEach(function (key) {
-        // ignore tab state saved by earlier versions of
-        // the extension which saved the state as a {key: <state string>}
-        // dict rather than {key: <state object>}
-        if (typeof loaded[key] === 'string') {
-          local[key] = { state: loaded[key] };
-        } else {
-          local[key] = loaded[key];
-        }
-      });
+      Object.keys(loaded).forEach(key => (local[key] = loaded[key]));
     } catch (e) {
       local = null;
     }

--- a/tests/background/tab-store-test.js
+++ b/tests/background/tab-store-test.js
@@ -34,14 +34,6 @@ describe('TabStore', function () {
         store.get(100);
       });
     });
-
-    it('converts state-string keys to objects', function () {
-      fakeLocalStorage.data.state = JSON.stringify({
-        1: 'active',
-      });
-      store.reload();
-      assert.deepEqual(store.get(1), { state: 'active' });
-    });
   });
 
   describe('.set', function () {


### PR DESCRIPTION
5 years ago a more flexible, multi-key object was introduced to capture the relevant information about the tabs. The old format, a `"inactive"|"active"` string was retired.

On every extension update the code that runs the conversion is executed. By now, every localStorage is in the new format, therefore this legacy code can safely be retired.