### PR TITLE
Fix Sentry problem in production and qa

### DIFF
--- a/src/background/raven.js
+++ b/src/background/raven.js
@@ -6,7 +6,7 @@
  * version to be provided via the app's settings object.
  */
 
-import * as Raven from 'raven-js';
+import Raven from 'raven-js';
 
 /**
  * Returns the input URL if it is an HTTP URL or the filename part of the URL

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -7,12 +7,9 @@
     "noEmit": true,
     "strict": true,
     "noImplicitAny": false,
-    "target": "ES2020"
+    "target": "ES2020",
+    "allowSyntheticDefaultImports": true
   },
-  "include": [
-    "**/*.js"
-  ],
-  "exclude": [
-    "vendor/"
-  ]
+  "include": ["**/*.js"],
+  "exclude": ["vendor/"]
 }


### PR DESCRIPTION
I believe a recent change in Babel has enabled the import of modules without `default` export.

With those changes if the import was like this:

`import * Raven from 'raven-js`

then functions needed to be invoked like this:

`Raven.default.config` (notice the `default` property)

I enabled `"allowSyntheticDefaultImports": true` in tsconfig.json to match the Babel behaviour.