### PR TITLE
Fix error when deactivating extension a second time in a tab

### DIFF
--- a/src/unload-client.js
+++ b/src/unload-client.js
@@ -3,13 +3,19 @@
 
 'use strict';
 
-const annotatorLink = document.querySelector(
-  'link[type="application/annotator+html"]'
-);
+// This wrapper function ensures that variables declared within `unloadClient`
+// are not visible to any scripts that are subsequently run by the JS extension.
+function unloadClient() {
+  const annotatorLink = document.querySelector(
+    'link[type="application/annotator+html"]'
+  );
 
-if (annotatorLink) {
-  // Dispatch a 'destroy' event which is handled by the code in
-  // annotator/main.js to remove the client.
-  const destroyEvent = new Event('destroy');
-  annotatorLink.dispatchEvent(destroyEvent);
+  if (annotatorLink) {
+    // Dispatch a 'destroy' event which is handled by the code in
+    // annotator/main.js to remove the client.
+    const destroyEvent = new Event('destroy');
+    annotatorLink.dispatchEvent(destroyEvent);
+  }
 }
+
+unloadClient();


### PR DESCRIPTION
Fix an error about a duplicate `annotatorLink` variable when
de-activating the extension in a tab where it had previously been
active.

It appears that injected scripts all share the same JS global, so if the
`unload-client.js` script is injected multiple times then subsequent
runs would fail due to the `annotatorLink` variable having already been
declared. This didn't happen in the past because the `const` was
transpiled down to `var`, which allows redeclaration. This no longer
happens.

Note that repeatedly activating and re-activating the extension on the same page
is currently broken due to a client issue: https://github.com/hypothesis/client/pull/2782. However, it is possible to reproduce the error on master. It happens when toggling the extension multiple times on the same tab without reloading the page.