### PR TITLE
Add HTML file for notebook app and set `notebookAppUrl` in client config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ extension: build/extension.bundle.js
 extension: build/manifest.json
 extension: build/client/build
 extension: build/client/app.html
+extension: build/client/notebook.html
 extension: build/settings-data.js
 extension: build/unload-client.js
 extension: build/pdfjs-init.js
@@ -58,6 +59,8 @@ build/client/build: node_modules/hypothesis/build/manifest.json
 	rm $@/manifest.json
 build/client/app.html: src/sidebar-app.html.mustache build/client build/.settings.json
 	tools/template-context-app.js build/.settings.json | $(MUSTACHE) - $< >$@
+build/client/notebook.html: build/client/app.html
+	cp $< $@
 build/settings-data.js: src/settings-data.js.mustache build/client build/.settings.json
 	tools/template-context-settings.js build/.settings.json | $(MUSTACHE) - $< >$@
 build/unload-client.js: src/unload-client.js

--- a/src/background/hypothesis-chrome-extension.js
+++ b/src/background/hypothesis-chrome-extension.js
@@ -287,6 +287,7 @@ export default function HypothesisChromeExtension({
         // load. See https://bugs.chromium.org/p/chromium/issues/detail?id=667533
         assetRoot: chromeExtension.getURL('/client/'),
         sidebarAppUrl: chromeExtension.getURL('/client/app.html'),
+        notebookAppUrl: chromeExtension.getURL('/client/notebook.html'),
       };
 
       // Pass the direct-link query as configuration into the client.

--- a/src/pdfjs-init.js
+++ b/src/pdfjs-init.js
@@ -5,6 +5,7 @@
 const clientConfig = {
   assetRoot: '/client/',
   sidebarAppUrl: '/client/app.html',
+  notebookAppUrl: '/client/notebook.html',
 };
 
 const configScript = document.createElement('script');

--- a/tests/background/hypothesis-chrome-extension-test.js
+++ b/tests/background/hypothesis-chrome-extension-test.js
@@ -632,6 +632,7 @@ describe('HypothesisChromeExtension', function () {
       onTabStateChange('active', 'inactive');
       assert.calledWith(fakeSidebarInjector.injectIntoTab, tab, {
         assetRoot: 'chrome://1234/client/',
+        notebookAppUrl: 'chrome://1234/client/notebook.html',
         sidebarAppUrl: 'chrome://1234/client/app.html',
       });
     });


### PR DESCRIPTION
This PR fixes an issue where a locally-built production extension fails to load, with an error occurring due to a missing `notebookAppUrl` config key in the client boot script. It adds rules to the Makefile to generate a `notebook.html` file and configures the client to set it as the URL of the notebook app.

While this PR fixes an immediate problem, there is a higher-level choice of whether we want the extension to "include" its own Notebook app and show that inside an iframe. We could instead make the "Open notebook" link just open https://hypothes.is/notebook (or equivalent URL depending on the h backend the extension is using) in a new tab. I figure we can merge this now and revisit later if we decide to go down that route.

---

To test locally:

1. Remove any existing install of the production Hypothesis client from the Chrome Web Store
2. Build production extension locally with `make SETTINGS_FILE=settings/chrome-prod.json`
3. Load the generated unpackaged extension from chrome://extensions
4. Go to a web page and try to activate the extension

On master the extension fails to activate due to missing `notebookAppUrl` config. On this branch the extension loads and the notebook can be launched via the "Open Notebook" menu item.

When the notebook app does launch, it currently just loads the sidebar app in the iframe, instead of the extension. This is because the client's router is configured to recognize `/notebook` as the URL to set the initial route and the actual URL in the  extension is `/notebook.html`. It is TBD how we'll resolve this. The easiest option would just be treat both `/notebook` and `/notebook.html` as paths that trigger the notebook app route in the client.
