### PR TITLE
Configure codecov to avoid irrelevant notifications

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        # prevent spurious codecov errors resulting from tiny fluctuations
+        threshold: 0.1%


### PR DESCRIPTION
Added configuration file to prevent spurious codecov notification
warnings resulting from tiny fluctuations