### PR TITLE
Replace query-string by `URL.searchParams`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "mustache": "^4.2.0",
     "prettier": "2.3.2",
     "puppeteer": "^10.1.0",
-    "query-string": "^3.0.1",
     "raven-js": "^3.27.2",
     "sinon": "^11.1.1",
     "typescript": "^4.3.5",

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -1,5 +1,3 @@
-import * as queryString from 'query-string';
-
 import detectContentType from './detect-content-type';
 import * as errors from './errors';
 import * as util from './util';
@@ -284,7 +282,7 @@ export default function SidebarInjector(
   function removeFromPDF(tab) {
     return new Promise(function (resolve) {
       const parsedURL = new URL(tab.url);
-      const originalURL = queryString.parse(parsedURL.search).file;
+      const originalURL = parsedURL.searchParams.get('file');
       if (!originalURL) {
         throw new Error('Failed to extract original URL from ' + tab.url);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6934,13 +6934,6 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-query-string@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-3.0.3.tgz#ae2e14b4d05071d4e9b9eb4873c35b0dcd42e638"
-  integrity sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=
-  dependencies:
-    strict-uri-encode "^1.0.0"
-
 querystring-es3@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -7893,11 +7886,6 @@ streamroller@^2.2.4:
     date-format "^2.1.0"
     debug "^4.1.1"
     fs-extra "^8.1.0"
-
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Remove a dependency by using `URL.searchParams` to extract a query param from a URL.

This also resolves a theoretical issue where the `originalURL` variable could end up being an array rather than a string if the `file` query param was repeated in the URL, although I don't know of non-contrived scenario (eg. user manually editing URL bar) in which that might happen.