### PR TITLE
Remove Google Analytics configuration from the extension

### DIFF
--- a/settings/chrome-dev.json
+++ b/settings/chrome-dev.json
@@ -7,8 +7,6 @@
   "serviceUrl": "http://localhost:5000/",
   "websocketUrl": "ws://localhost:5001/ws",
 
-  "googleAnalytics": "UA-26026798-6",
-
   "browserIsChrome": true,
   "appType": "chrome-extension"
 }

--- a/settings/chrome-prod.json
+++ b/settings/chrome-prod.json
@@ -12,7 +12,6 @@
   "oauthClientId": "fd23fe2e-7792-11e7-8e16-23e47a1799d4",
 
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
-  "googleAnalytics": "UA-26026798-5",
 
   "browserIsChrome": true,
   "appType": "chrome-extension"

--- a/settings/chrome-qa.json
+++ b/settings/chrome-qa.json
@@ -11,7 +11,6 @@
   "oauthClientId": "da545114-7792-11e7-90b4-b35c52774c7d",
 
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
-  "googleAnalytics": "UA-26026798-6",
 
   "browserIsChrome": true,
   "appType": "chrome-extension"

--- a/settings/firefox-dev.json
+++ b/settings/firefox-dev.json
@@ -6,8 +6,6 @@
   "serviceUrl": "http://localhost:5000/",
   "websocketUrl": "ws://localhost:5001/ws",
 
-  "googleAnalytics": "UA-26026798-6",
-
   "browserIsFirefox": true,
   "appType": "firefox-extension"
 }

--- a/settings/firefox-prod.json
+++ b/settings/firefox-prod.json
@@ -10,7 +10,6 @@
   "oauthClientId": "7fb28342-7793-11e7-90b5-7fed4053f592",
 
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
-  "googleAnalytics": "UA-26026798-5",
 
   "browserIsFirefox": true,
   "appType": "firefox-extension"

--- a/settings/firefox-qa.json
+++ b/settings/firefox-qa.json
@@ -10,7 +10,6 @@
   "oauthClientId": "92b42e3c-7793-11e7-8e17-cb2151436a1f",
 
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
-  "googleAnalytics": "UA-26026798-6",
 
   "browserIsFirefox": true,
   "appType": "firefox-extension"

--- a/tools/template-context-app.js
+++ b/tools/template-context-app.js
@@ -26,9 +26,6 @@ function appSettings(settings) {
       release: settings.version,
     };
   }
-  if (settings.googleAnalytics) {
-    result.googleAnalytics = settings.googleAnalytics;
-  }
   if (settings.oauthClientId) {
     result.oauthClientId = settings.oauthClientId;
   }

--- a/tools/template-context-settings.js
+++ b/tools/template-context-settings.js
@@ -21,9 +21,6 @@ function extensionSettings(settings) {
       release: settings.version,
     };
   }
-  if (settings.googleAnalytics) {
-    result.googleAnalytics = settings.googleAnalytics;
-  }
   return result;
 }
 


### PR DESCRIPTION
This configuration was used to set the Google Analytics ID used by the
Hypothesis client loaded from the extension. The client no longer uses
GA however.

Related change in h: https://github.com/hypothesis/h/pull/6929