### PR TITLE
Simplify `content_security_policy` in manifest

### DIFF
--- a/src/manifest.json.mustache
+++ b/src/manifest.json.mustache
@@ -54,7 +54,8 @@
     "storage",
     "tabs"
   ],
-  "content_security_policy": "script-src 'self' 'unsafe-eval' https://www.google-analytics.com; object-src 'self'; font-src 'self' data:;",
+
+  "content_security_policy": "script-src 'self'; object-src 'self'",
 
   "background": {
     {{#browserIsChrome}}


### PR DESCRIPTION
The Hypothesis client no longer uses Google Analytics, inline JavaScript
(eval) or inline fonts.

The default value of `content_security_policy` would now work, although
we can actually be more strict. The default policy allows additional
script sources (blob, filesystem) which we don't need.