### PR TITLE
Fix PDF.js viewer failing to load without unsafe-eval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,11 +88,7 @@ build/settings-data.js: src/settings-data.js.mustache build/client build/.settin
 	tools/template-context-settings.js build/.settings.json | $(MUSTACHE) - $< >$@
 build/unload-client.js: src/unload-client.js
 	cp $< $@
-build/pdfjs-init.js: src/pdfjs-init.js
-	cp $< $@
-build/pdfjs-setup-env.js: src/pdfjs-setup-env.js
-	cp $< $@
-build/pdfjs-worker-init.js: src/pdfjs-worker-init.js
+build/pdfjs-%.js: src/pdfjs-%.js
 	cp $< $@
 build/pdfjs: src/vendor/pdfjs
 	cp -R $< $@

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ extension: build/client/notebook.html
 extension: build/settings-data.js
 extension: build/unload-client.js
 extension: build/pdfjs-init.js
+extension: build/pdfjs-setup-env.js
+extension: build/pdfjs-worker-init.js
 extension: $(addprefix build/,$(EXTENSION_SRC))
 
 build/extension.bundle.js: src/background/index.js
@@ -87,6 +89,10 @@ build/settings-data.js: src/settings-data.js.mustache build/client build/.settin
 build/unload-client.js: src/unload-client.js
 	cp $< $@
 build/pdfjs-init.js: src/pdfjs-init.js
+	cp $< $@
+build/pdfjs-setup-env.js: src/pdfjs-setup-env.js
+	cp $< $@
+build/pdfjs-worker-init.js: src/pdfjs-worker-init.js
 	cp $< $@
 build/pdfjs: src/vendor/pdfjs
 	cp -R $< $@

--- a/src/pdfjs-init.js
+++ b/src/pdfjs-init.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// This script is run once PDF.js has loaded and it configures the viewer
+// and injects the Hypothesis client.
+
 // Configure Hypothesis client to load assets from the extension instead of
 // the CDN.
 const clientConfig = {
@@ -21,6 +24,9 @@ document.addEventListener('webviewerloaded', () => {
   const appOptions = window.PDFViewerApplicationOptions;
   // @ts-expect-error - PDFViewerApplication is missing from types.
   const app = window.PDFViewerApplication;
+
+  // Configure PDF.js to use custom entry point for worker.
+  appOptions.set('workerSrc', '/pdfjs-worker-init.js');
 
   // Ensure that PDF.js viewer events such as "documentloaded" are dispatched
   // to the DOM. The client relies on this.

--- a/src/pdfjs-setup-env.js
+++ b/src/pdfjs-setup-env.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// This script sets up the global environment before the PDF.js scripts are
+// loaded. This is used both in document and web worker contexts.
+
+// Pre-define `regeneratorRuntime` so that PDF.js doesn't crash if loaded
+// in an environment which disallows execution of inline scripts.
+//
+// We can remove this after upgrading to a newer version of PDF.js which uses
+// native async/await support.
+//
+// @ts-ignore
+self.regeneratorRuntime = null;

--- a/src/pdfjs-worker-init.js
+++ b/src/pdfjs-worker-init.js
@@ -1,0 +1,6 @@
+'use strict';
+
+/* eslint-env worker */
+
+// @ts-ignore
+importScripts('/pdfjs-setup-env.js', '/pdfjs/build/pdf.worker.js');

--- a/src/vendor/pdfjs/web/viewer.html
+++ b/src/vendor/pdfjs/web/viewer.html
@@ -34,6 +34,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 
 <!-- This snippet is used in production (included from viewer.html) -->
 <link rel="resource" type="application/l10n" href="locale/locale.properties">
+<script src="/pdfjs-setup-env.js"></script>
 <script src="../build/pdf.js"></script>
 
 


### PR DESCRIPTION
Fix loading of the PDF.js viewer (viewer.html) after removing the
unsafe-eval permission from the extension's content security policy.

It turns out that an async/await polyfill (regenerator) in PDF.js's
source bundles relied on this in a fallback code path if assigning a
global `regeneratorRuntime` variable failed:

```js
// Simplified version of code in various PDF.js code bundles
try {
  // Code that fails if script is run in "strict" mode and `regeneratorRuntime` is not already defined
  regeneratorRuntime = <value>
} catch (...) {
  // Fallback code path that relies on `eval`.
  new Function('r', 'regeneratorRuntime = r')(<value>)
}
```

Fix the issue by predefining the `regeneratorRuntime` global before
PDF.js loads. We should be able to remove this in future after upgrading
to a release of PDF.js that uses native async/await. The change in this PR
is simpler than a major PDF.js version update though.

 - Add `pdfjs-setup-env.js` as a place to prepare the global environment
   before PDF.js loads and predefine `regeneratorRuntime` in it

 - Load pdfjs-setup-env.js before PDF.js in viewer.html

 - Configure PDF.js to use a custom wrapper around pdf.worker.js in
   pdfjs-init.js. This wrapper, in pdfjs-worker-init.js, loads
   pdfjs-setup-envjs before the real worker script.

----

**Testing:**

- Build the extension locally, check that you can view and annotate a PDF with it
- When viewing a PDF, check that there are no worker-related warnings or errors in the console (eg. messages about using a "fake worker")