### PR TITLE
Support injecting client into VitalSource Bookshelf

### DIFF
--- a/src/manifest.json.mustache
+++ b/src/manifest.json.mustache
@@ -55,6 +55,11 @@
     "tabs"
   ],
 
+  "optional_permissions": [
+    {{! Used to enumerate frames on certain websites. }}
+    "webNavigation"
+  ],
+
   "content_security_policy": "script-src 'self'; object-src 'self'",
 
   "background": {

--- a/tests/background/chrome-api-test.js
+++ b/tests/background/chrome-api-test.js
@@ -26,6 +26,10 @@ describe('getChromeAPI', () => {
         getURL: sinon.stub(),
       },
 
+      permissions: {
+        request: sinon.stub(),
+      },
+
       tabs: {
         create: sinon.stub(),
         get: sinon.stub(),
@@ -86,5 +90,33 @@ describe('getChromeAPI', () => {
     }
 
     assert.equal(error, fakeChrome.runtime.lastError);
+  });
+
+  describe('APIs that require optional permissions', () => {
+    it('rejects if permission has not been granted', async () => {
+      const chromeAPI = getChromeAPI(fakeChrome);
+
+      let error;
+      try {
+        await chromeAPI.webNavigation.getAllFrames();
+      } catch (e) {
+        error = e;
+      }
+
+      assert.ok(error);
+    });
+
+    it('succeeds if permission has been granted', async () => {
+      const chromeAPI = getChromeAPI(fakeChrome);
+
+      const frames = [];
+      fakeChrome.webNavigation = {
+        getAllFrames: sinon.stub().yields(frames),
+      };
+
+      const actualFrames = await chromeAPI.webNavigation.getAllFrames();
+
+      assert.equal(actualFrames, frames);
+    });
   });
 });


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/browser-extension/pull/663**

This PR adds support for loading the client into the VitalSource Bookshelf reader from within the browser extension context.

The initial use case is to make it easier for developers to test the VitalSource integration with various versions of the client (development, QA, production) and without having to go through the LMS app, which complicates the testing environment significantly.

Compared to a regular HTML document, the main difference with loading the client into bookshelf is that we need to target a specific frame which is not the top-level frame in the tab. The current implementation very specifically targets bookshelf, but we could make this more generic. In other words, provide infrastructure in the extension to teach it to inject the client into specific frames depending on the top-level URL in the tab. This might support other use cases in future.