### PR TITLE
Modernize and add types to `SidebarInjector`

### DIFF
--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -323,14 +323,7 @@ export default function SidebarInjector(
    */
   function injectConfig(tabId, config) {
     const configStr = JSON.stringify(config).replace(/"/g, '\\"');
-    const configCode =
-      'var hypothesisConfig = "' +
-      configStr +
-      '";\n' +
-      '(' +
-      addJSONScriptTagFn.toString() +
-      ')' +
-      '("js-hypothesis-config", hypothesisConfig);\n';
+    const configCode = `var hypothesisConfig="${configStr}";\n(${addJSONScriptTagFn})("js-hypothesis-config", hypothesisConfig);\n`;
     return executeScriptFn(tabId, { code: configCode });
   }
 }

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -95,12 +95,13 @@ export default function SidebarInjector(
     }
   };
 
-  /* Removes the Hypothesis sidebar from the tab provided.
-   *
-   * tab - A tab object representing the tab to remove the sidebar from.
+  /**
+   * Removes the Hypothesis sidebar from the tab provided.
    *
    * Returns a promise that will be resolved if the removal succeeded
    * otherwise it will be rejected with an error.
+   *
+   * @param {chrome.tabs.Tab} tab
    */
   this.removeFromTab = function (tab) {
     if (isPDFViewerURL(tab.url)) {

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -143,7 +143,7 @@ export default function SidebarInjector(
    * a content script to determine the type of content in the page.
    */
   function guessContentTypeFromURL(url) {
-    if (url.indexOf('.pdf') !== -1) {
+    if (url.includes('.pdf')) {
       return CONTENT_TYPE_PDF;
     } else {
       return CONTENT_TYPE_HTML;
@@ -185,11 +185,11 @@ export default function SidebarInjector(
    * viewer bundled with the extension.
    */
   function isPDFViewerURL(url) {
-    return url.indexOf(pdfViewerBaseURL) === 0;
+    return url.startsWith(pdfViewerBaseURL);
   }
 
   function isFileURL(url) {
-    return url.indexOf('file:') === 0;
+    return url.startsWith('file:');
   }
 
   function isSupportedURL(url) {
@@ -242,9 +242,8 @@ export default function SidebarInjector(
       const results = await injectIntoHTML(tab);
       const result = extractContentScriptResult(results);
       if (
-        result &&
-        typeof result.installedURL === 'string' &&
-        result.installedURL.indexOf(extensionURL('/')) === -1
+        typeof result?.installedURL === 'string' &&
+        !result.installedURL.includes(extensionURL('/'))
       ) {
         throw new AlreadyInjectedError(
           'Hypothesis is already injected into this page'
@@ -289,7 +288,7 @@ export default function SidebarInjector(
       // If the original URL was a direct link, drop the #annotations fragment
       // as otherwise the Chrome extension will re-activate itself on this tab
       // when the original URL loads.
-      if (hash.indexOf('#annotations:') === 0) {
+      if (hash.startsWith('#annotations:')) {
         hash = '';
       }
 

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -21,7 +21,7 @@ function toIIFEString(fn) {
  * content script, so it cannot reference any external variables.
  */
 /* istanbul ignore next */
-function addJSONScriptTagFn(name, content) {
+function addJSONScriptTag(name, content) {
   const scriptTag = document.createElement('script');
   scriptTag.className = name;
   scriptTag.textContent = content;
@@ -71,7 +71,7 @@ export default function SidebarInjector(
   chromeTabs,
   { isAllowedFileSchemeAccess, extensionURL }
 ) {
-  const executeScriptFn = promisify(chromeTabs.executeScript);
+  const executeScript = promisify(chromeTabs.executeScript);
 
   const PDFViewerBaseURL = extensionURL('/pdfjs/web/viewer.html');
 
@@ -156,7 +156,7 @@ export default function SidebarInjector(
 
     return canInjectScript(tab.url).then(function (canInject) {
       if (canInject) {
-        return executeScriptFn(tab.id, {
+        return executeScript(tab.id, {
           code: toIIFEString(detectContentType),
         }).then(function (frameResults) {
           const result = extractContentScriptResult(frameResults);
@@ -256,8 +256,8 @@ export default function SidebarInjector(
     if (isPDFViewerURL(tab.url)) {
       return Promise.resolve();
     }
-    const updateFn = promisify(chromeTabs.update);
-    return updateFn(tab.id, { url: getPDFViewerURL(tab.url) });
+    const update = promisify(chromeTabs.update);
+    return update(tab.id, { url: getPDFViewerURL(tab.url) });
   }
 
   function injectIntoLocalPDF(tab) {
@@ -314,7 +314,7 @@ export default function SidebarInjector(
    * page currently loaded in the tab at the given ID.
    */
   function injectScript(tabId, path) {
-    return executeScriptFn(tabId, { file: path });
+    return executeScript(tabId, { file: path });
   }
 
   /**
@@ -326,7 +326,7 @@ export default function SidebarInjector(
    */
   function injectConfig(tabId, config) {
     const configStr = JSON.stringify(config).replace(/"/g, '\\"');
-    const configCode = `var hypothesisConfig="${configStr}";\n(${addJSONScriptTagFn})("js-hypothesis-config", hypothesisConfig);\n`;
-    return executeScriptFn(tabId, { code: configCode });
+    const configCode = `var hypothesisConfig="${configStr}";\n(${addJSONScriptTag})("js-hypothesis-config", hypothesisConfig);\n`;
+    return executeScript(tabId, { code: configCode });
   }
 }

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -196,10 +196,7 @@ export default function SidebarInjector(
     // Injection of content scripts is limited to a small number of protocols,
     // see https://developer.chrome.com/extensions/match_patterns
     const parsedURL = new URL(url);
-    const SUPPORTED_PROTOCOLS = ['http:', 'https:', 'ftp:'];
-    return SUPPORTED_PROTOCOLS.some(function (protocol) {
-      return parsedURL.protocol === protocol;
-    });
+    return ['http:', 'https:', 'ftp:'].includes(parsedURL.protocol);
   }
 
   function injectIntoLocalDocument(tab) {

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -73,7 +73,7 @@ export default function SidebarInjector(
 ) {
   const executeScript = promisify(chromeTabs.executeScript);
 
-  const PDFViewerBaseURL = extensionURL('/pdfjs/web/viewer.html');
+  const pdfViewerBaseURL = extensionURL('/pdfjs/web/viewer.html');
 
   /**
    * Injects the Hypothesis sidebar into the tab provided.
@@ -119,7 +119,7 @@ export default function SidebarInjector(
     const hash = parsedURL.hash;
     parsedURL.hash = '';
     const encodedURL = encodeURIComponent(parsedURL.href);
-    return PDFViewerBaseURL + '?file=' + encodedURL + hash;
+    return pdfViewerBaseURL + '?file=' + encodedURL + hash;
   }
 
   // returns true if the extension is permitted to inject
@@ -185,7 +185,7 @@ export default function SidebarInjector(
    * viewer bundled with the extension.
    */
   function isPDFViewerURL(url) {
-    return url.indexOf(PDFViewerBaseURL) === 0;
+    return url.indexOf(pdfViewerBaseURL) === 0;
   }
 
   function isFileURL(url) {

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -270,7 +270,7 @@ export default function SidebarInjector(
   }
 
   function injectIntoHTML(tab) {
-    return injectScript(tab.id, '/client/build/boot.js');
+    return executeScript(tab.id, { file: '/client/build/boot.js' });
   }
 
   function removeFromPDF(tab) {
@@ -303,15 +303,7 @@ export default function SidebarInjector(
     if (!isSupportedURL(tab.url)) {
       return Promise.resolve();
     }
-    return injectScript(tab.id, '/unload-client.js');
-  }
-
-  /**
-   * Inject the script from the source file at `path` into the
-   * page currently loaded in the tab at the given ID.
-   */
-  function injectScript(tabId, path) {
-    return executeScript(tabId, { file: path });
+    return executeScript(tab.id, { file: '/unload-client.js' });
   }
 
   /**

--- a/tests/background/sidebar-injector-test.js
+++ b/tests/background/sidebar-injector-test.js
@@ -108,6 +108,19 @@ describe('SidebarInjector', function () {
       );
     });
 
+    [{ id: 1 }, { url: 'https://foobar.com' }].forEach(tab => {
+      it('throws if tab does not have ID or URL', async () => {
+        let error;
+        try {
+          await injector.injectIntoTab(tab);
+        } catch (e) {
+          error = e;
+        }
+        assert.instanceOf(error, Error);
+        assert.equal(error.message, 'Tab is missing ID or URL');
+      });
+    });
+
     it('succeeds if the tab is already displaying the embedded PDF viewer', function () {
       const url =
         PDF_VIEWER_BASE_URL + encodeURIComponent('http://origin/foo.pdf');


### PR DESCRIPTION
This PR is some modernization of `SidebarInjector` and addition of types in preparation for VitalSource-related changes.

There is more to come later, but these changes felt like enough for one PR. See the individual commits for details.

One issue that was raised by the addition of types is that some unusual types ([see notes in Chrome docs](https://developer.chrome.com/docs/extensions/reference/tabs/#type-Tab)) may be missing ID or URL information. I'm not sure if it is possible to actually trigger injection of the client on these tabs, but as of this PR we at least check and throw an error if it is missing.