### PR TITLE
Update the browser version support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,3 @@
 {
-  "presets": [
-    [
-      "@babel/preset-env",
-      {
-        "targets": {
-          "chrome": "64",
-          "firefox": "68"
-        }
-      }
-    ]
-  ]
+  "presets": [["@babel/preset-env"]]
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "watchify": "^4.0.0",
     "web-ext": "^6.4.0"
   },
+  "browserslist": "chrome 85, firefox 75",
   "scripts": {
     "test": "karma start tests/karma.config.js --single-run",
     "typecheck": "tsc --build src/tsconfig.json"


### PR DESCRIPTION
After the latest PDF.js version update, we require chrome >= 85.  See
https://hypothes-is.slack.com/archives/C1M8NH76X/p1631787431008100

Moved the browser list from .babelrc to package.json