### PR TITLE
Simplify async code in SidebarInjector

### DIFF
--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -317,7 +317,7 @@ export function SidebarInjector() {
     const parsedURL = new URL(tab.url);
     const originalURL = parsedURL.searchParams.get('file');
     if (!originalURL) {
-      throw new Error('Failed to extract original URL from ' + tab.url);
+      throw new Error(`Failed to extract original URL from ${tab.url}`);
     }
     let hash = parsedURL.hash;
 


### PR DESCRIPTION
Simplify async code in SidebarInjector by using async/await to replace
promise chains and `promisify` to convert some callback-accepting Chrome
APIs to Promise-returning functions.