### PR TITLE
Convert default exports to named exports

### DIFF
--- a/src/background/browser-action.js
+++ b/src/background/browser-action.js
@@ -45,7 +45,7 @@ function _(str) {
  *
  * @param {chrome.browserAction} chromeBrowserAction
  */
-export default function BrowserAction(chromeBrowserAction) {
+export function BrowserAction(chromeBrowserAction) {
   const buildType = settings.buildType;
 
   /**

--- a/src/background/detect-content-type.js
+++ b/src/background/detect-content-type.js
@@ -13,7 +13,7 @@
  * @param {Document} document_ - Test seam
  */
 /* istanbul ignore next */
-export default function detectContentType(document_ = document) {
+export function detectContentType(document_ = document) {
   function detectChromePDFViewer() {
     // When viewing a PDF in Chrome, the viewer consists of a top-level
     // document with an <embed> tag, which in turn instantiates an inner HTML

--- a/src/background/direct-link-query.js
+++ b/src/background/direct-link-query.js
@@ -22,7 +22,7 @@
  * @return {Query|null}
  *   The direct link query translated into client configuration settings.
  */
-export default function directLinkQuery(url) {
+export function directLinkQuery(url) {
   // Annotation IDs are url-safe-base64 identifiers
   // See https://tools.ietf.org/html/rfc4648#page-7
   const idMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);

--- a/src/background/help-page.js
+++ b/src/background/help-page.js
@@ -9,7 +9,7 @@ import * as errors from './errors';
  *   to the file inside the chrome extension. See:
  *   https://developer.chrome.com/extensions/extension#method-getURL
  */
-export default function HelpPage(chromeTabs, extensionURL, browserName_) {
+export function HelpPage(chromeTabs, extensionURL, browserName_) {
   browserName_ = browserName_ || browserName;
 
   /* Accepts an instance of errors.ExtensionError and displays an appropriate

--- a/src/background/hypothesis-chrome-extension.js
+++ b/src/background/hypothesis-chrome-extension.js
@@ -1,11 +1,11 @@
-import BrowserAction from './browser-action';
-import directLinkQuery from './direct-link-query';
+import { BrowserAction } from './browser-action';
+import { directLinkQuery } from './direct-link-query';
 import * as errors from './errors';
-import HelpPage from './help-page';
+import { HelpPage } from './help-page';
 import settings from './settings';
-import SidebarInjector from './sidebar-injector';
-import TabState from './tab-state';
-import TabStore from './tab-store';
+import { SidebarInjector } from './sidebar-injector';
+import { TabState } from './tab-state';
+import { TabStore } from './tab-store';
 
 /**
  * The main extension application. This wires together all the smaller

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -1,4 +1,4 @@
-import detectContentType from './detect-content-type';
+import { detectContentType } from './detect-content-type';
 import {
   AlreadyInjectedError,
   LocalFileError,
@@ -95,7 +95,7 @@ function checkTab(tab) {
  *   A function that receives a path and returns an absolute
  *   url. See: https://developer.chrome.com/extensions/extension#method-getURL
  */
-export default function SidebarInjector(
+export function SidebarInjector(
   chromeTabs,
   { isAllowedFileSchemeAccess, extensionURL }
 ) {

--- a/src/background/tab-state.js
+++ b/src/background/tab-state.js
@@ -50,7 +50,7 @@ const DEFAULT_STATE = {
  * @param {(tabId: number, current: undefined|State) => any} [onchange] -
  *   Callback invoked when state for a tab changes
  */
-export default function TabState(initialState, onchange) {
+export function TabState(initialState, onchange) {
   /**
    * Current Hypothesis-related state for each tab.
    *

--- a/src/background/tab-store.js
+++ b/src/background/tab-store.js
@@ -1,11 +1,12 @@
-/** TabStore is used to persist the state of H browser tabs when
+/**
+ * TabStore is used to persist the state of H browser tabs when
  * the extension is re-installed or updated.
  *
  * Note: This could also be used to persist the state across browser sessions,
  * for that to work however the storage key would need to be changed.
  * The tab ID is currently used but this is valid only for a browser session.
  */
-export default function TabStore(storage) {
+export function TabStore(storage) {
   const key = 'state';
   let local;
 

--- a/tests/background/browser-action-test.js
+++ b/tests/background/browser-action-test.js
@@ -1,4 +1,4 @@
-import BrowserAction, { $imports } from '../../src/background/browser-action';
+import { BrowserAction, $imports } from '../../src/background/browser-action';
 
 describe('BrowserAction', function () {
   let action;

--- a/tests/background/detect-content-type-test.js
+++ b/tests/background/detect-content-type-test.js
@@ -1,6 +1,6 @@
-import detectContentType from '../../src/background/detect-content-type';
+import { detectContentType } from '../../src/background/detect-content-type';
 
-describe('detectContentType()', function () {
+describe('detectContentType', function () {
   let el;
   beforeEach(function () {
     el = document.createElement('div');

--- a/tests/background/direct-link-query-test.js
+++ b/tests/background/direct-link-query-test.js
@@ -1,4 +1,4 @@
-import directLinkQuery from '../../src/background/direct-link-query';
+import { directLinkQuery } from '../../src/background/direct-link-query';
 
 describe('common.direct-link-query', () => {
   it('returns `null` if the URL contains no #annotations fragment', () => {

--- a/tests/background/help-page-test.js
+++ b/tests/background/help-page-test.js
@@ -1,5 +1,5 @@
 import * as errors from '../../src/background/errors';
-import HelpPage from '../../src/background/help-page';
+import { HelpPage } from '../../src/background/help-page';
 
 describe('HelpPage', function () {
   let fakeBrowserName;

--- a/tests/background/hypothesis-chrome-extension-test.js
+++ b/tests/background/hypothesis-chrome-extension-test.js
@@ -123,11 +123,15 @@ describe('HypothesisChromeExtension', function () {
     FakeTabState.prototype = fakeTabState;
 
     $imports.$mock({
-      './tab-state': FakeTabState,
-      './tab-store': createConstructor(fakeTabStore),
-      './help-page': createConstructor(fakeHelpPage),
-      './browser-action': createConstructor(fakeBrowserAction),
-      './sidebar-injector': createConstructor(fakeSidebarInjector),
+      './tab-state': { TabState: FakeTabState },
+      './tab-store': { TabStore: createConstructor(fakeTabStore) },
+      './help-page': { HelpPage: createConstructor(fakeHelpPage) },
+      './browser-action': {
+        BrowserAction: createConstructor(fakeBrowserAction),
+      },
+      './sidebar-injector': {
+        SidebarInjector: createConstructor(fakeSidebarInjector),
+      },
       './errors': fakeErrors,
       './settings': {
         default: {

--- a/tests/background/sidebar-injector-test.js
+++ b/tests/background/sidebar-injector-test.js
@@ -1,5 +1,5 @@
 import * as errors from '../../src/background/errors';
-import SidebarInjector from '../../src/background/sidebar-injector';
+import { SidebarInjector } from '../../src/background/sidebar-injector';
 import { toResult } from '../promise-util';
 
 // The root URL for the extension returned by the

--- a/tests/background/tab-state-test.js
+++ b/tests/background/tab-state-test.js
@@ -1,4 +1,4 @@
-import TabState, { $imports } from '../../src/background/tab-state';
+import { TabState, $imports } from '../../src/background/tab-state';
 
 describe('TabState', () => {
   let state;

--- a/tests/background/tab-store-test.js
+++ b/tests/background/tab-store-test.js
@@ -1,4 +1,4 @@
-import TabStore from '../../src/background/tab-store';
+import { TabStore } from '../../src/background/tab-store';
 
 describe('TabStore', function () {
   let store;


### PR DESCRIPTION
Per current coding conventions, use named rather than default exports.