### PR TITLE
Automatic type substitution of Object for object

### DIFF
--- a/src/background/direct-link-query.js
+++ b/src/background/direct-link-query.js
@@ -4,7 +4,7 @@
  *
  * See https://h-client.readthedocs.io/en/latest/publishers/config/#config-settings
  *
- * @typedef {Object} Query
+ * @typedef Query
  * @property {string} [annotations] - ID of the direct-linked annotation
  * @property {string} [query] - Filter query from the sidebar
  * @property {string} [group] - ID of the direct-linked group

--- a/src/background/errors.js
+++ b/src/background/errors.js
@@ -61,7 +61,7 @@ export function shouldIgnoreInjectionError(err) {
  *
  * @param {Error} error - The error which happened.
  * @param {string} when - Describes the context in which the error occurred.
- * @param {Object} context - Additional context for the error.
+ * @param {object} context - Additional context for the error.
  */
 export function report(error, when, context) {
   console.error(when, error);

--- a/src/background/hypothesis-chrome-extension.js
+++ b/src/background/hypothesis-chrome-extension.js
@@ -29,7 +29,7 @@ import TabStore from './tab-store';
  * - https://developer.chrome.com/extensions/tabs
  * - https://developer.chrome.com/extensions/extension
  *
- * @param {Object} services
+ * @param {object} services
  * @param {chrome.tabs} services.chromeTabs
  * @param {chrome.extension} services.chromeExtension
  * @param {chrome.storage} services.chromeStorage

--- a/src/background/raven.js
+++ b/src/background/raven.js
@@ -69,10 +69,10 @@ export function init(config) {
 /**
  * Report an error to Sentry.
  *
- * @param {Object} error - An error object describing what went wrong
+ * @param {object} error - An error object describing what went wrong
  * @param {string} when - A string describing the context in which
  *                        the error occurred.
- * @param {Object} [context] - A JSON-serializable object containing additional
+ * @param {object} [context] - A JSON-serializable object containing additional
  *                             information which may be useful when
  *                             investigating the error.
  */

--- a/src/background/settings.js
+++ b/src/background/settings.js
@@ -1,7 +1,7 @@
 /**
  * Validate and normalize the given settings data.
  *
- * @param {Object} settings The settings from the settings.json file.
+ * @param {object} settings The settings from the settings.json file.
  */
 function normalizeSettings(settings) {
   // Make sure that apiUrl does not end with a /.

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -86,7 +86,7 @@ function checkTab(tab) {
  * when applicable.
  *
  * @param {chrome.tabs} chromeTabs
- * @param {Object} services
+ * @param {object} services
  * @param {(cb: (allowed: boolean) => void) => void} services.isAllowedFileSchemeAccess -
  *   A function that returns true if the user
  *   can access resources over the file:// protocol. See:


### PR DESCRIPTION
For the past few months, we have started to use the `object` type instead of `Object`. Both are almost interchangeable, but we prefer `object` for simplicity.

This PR substitutes all `Object` to `object` and makes the code more consistent.

I used these commands (Mac version):

```
% ag -0 -l '@.+Object' | xargs -0 sed -ri '' -e '/@/s/(.*{.*)Object(.*})/\1object\2/'
```