### PR TITLE
Refactor HelpPage class

### DIFF
--- a/src/background/help-page.js
+++ b/src/background/help-page.js
@@ -1,73 +1,49 @@
-import browserName from './browser-name';
-import * as errors from './errors';
+import { chromeAPI } from './chrome-api';
+import {
+  BlockedSiteError,
+  LocalFileError,
+  NoFileAccessError,
+  RestrictedProtocolError,
+} from './errors';
+
+/** @typedef {import('./errors').ExtensionError} ExtensionError */
 
 /**
  * A controller for displaying help pages. These are bound to extension
  * specific errors (found in errors.js) but can also be triggered manually.
- *
- * @param {chrome.tabs} chromeTabs - An instance of chrome.tabs.
- * @param {(path: string) => string} extensionURL -
- *   A function that recieves a path and returns a full path to the file inside
- *   the chrome extension. See: https://developer.chrome.com/extensions/extension#method-getURL
- * @param {() => string} [browserName_]
  */
-export function HelpPage(chromeTabs, extensionURL, browserName_ = browserName) {
+export class HelpPage {
   /**
    * Accepts an instance of errors.ExtensionError and displays an appropriate
    * help page if one exists.
    *
-   * @param {chrome.tabs.Tab} tab - The tab to display the error message in.
-   * @param {Error} error - The error to display, usually an instance of
-   *                        errors.ExtensionError
+   * @param {chrome.tabs.Tab} tab - The tab where the error occurred
+   * @param {Error} error - The error to display, usually an instance of {@link ExtensionError}
    */
-  this.showHelpForError = function (tab, error) {
-    if (error instanceof errors.LocalFileError) {
-      return this.showLocalFileHelpPage(tab);
-    } else if (error instanceof errors.NoFileAccessError) {
-      return this.showNoFileAccessHelpPage(tab);
-    } else if (error instanceof errors.RestrictedProtocolError) {
-      return this.showRestrictedProtocolPage(tab);
-    } else if (error instanceof errors.BlockedSiteError) {
-      return this.showBlockedSitePage(tab);
+  showHelpForError(tab, error) {
+    let section;
+    if (error instanceof LocalFileError) {
+      section = 'local-file';
+    } else if (error instanceof NoFileAccessError) {
+      section = 'no-file-access';
+    } else if (error instanceof RestrictedProtocolError) {
+      section = 'restricted-protocol';
+    } else if (error instanceof BlockedSiteError) {
+      section = 'blocked-site';
     } else {
-      return this.showOtherErrorPage(tab, error);
+      section = 'other-error';
     }
-  };
 
-  this.showLocalFileHelpPage = showHelpPage.bind(null, 'local-file');
-  this.showNoFileAccessHelpPage = showHelpPage.bind(null, 'no-file-access');
-  this.showRestrictedProtocolPage = showHelpPage.bind(
-    null,
-    'restricted-protocol'
-  );
-  this.showBlockedSitePage = showHelpPage.bind(null, 'blocked-site');
-  this.showOtherErrorPage = showHelpPage.bind(null, 'other-error');
-
-  /**
-   * Open a tab displaying the help page.
-   *
-   * @param {string} helpSection - ID of a <section> within the help page.
-   * @param {chrome.tabs.Tab} tab - The tab where the error occurred.
-   * @param {Error} [error] - The error which prompted the help page.
-   */
-  function showHelpPage(helpSection, tab, error) {
-    let params = '';
+    const url = new URL(chromeAPI.runtime.getURL('/help/index.html'));
     if (error) {
-      params = '?message=' + encodeURIComponent(error.message);
+      url.searchParams.append('message', error.message);
     }
+    url.hash = section;
 
-    /** @type {chrome.tabs.CreateProperties} */
-    const tabOpts = {
+    chromeAPI.tabs.create({
       index: tab.index + 1,
-      url: extensionURL('/help/index.html' + params + '#' + helpSection),
-    };
-
-    // Add `openerTabId` property to associate the help page tab with the
-    // current tab. This property is not supported in Firefox.
-    if (browserName_() !== 'firefox') {
-      tabOpts.openerTabId = tab.id;
-    }
-
-    chromeTabs.create(tabOpts);
+      url: url.toString(),
+      openerTabId: tab.id,
+    });
   }
 }

--- a/src/background/hypothesis-chrome-extension.js
+++ b/src/background/hypothesis-chrome-extension.js
@@ -34,16 +34,14 @@ import { TabStore } from './tab-store';
  * @param {chrome.extension} services.chromeExtension
  * @param {chrome.storage} services.chromeStorage
  * @param {chrome.browserAction} services.chromeBrowserAction
- * @param {(path: string) => string} services.extensionURL
  */
 export default function HypothesisChromeExtension({
   chromeTabs,
   chromeExtension,
   chromeStorage,
   chromeBrowserAction,
-  extensionURL,
 }) {
-  const help = new HelpPage(chromeTabs, extensionURL);
+  const help = new HelpPage();
   const store = new TabStore(localStorage);
   const state = new TabState(store.all(), onTabStateChange);
   const browserAction = new BrowserAction(chromeBrowserAction);

--- a/src/background/install.js
+++ b/src/background/install.js
@@ -9,9 +9,6 @@ export function init() {
     chromeTabs: chrome.tabs,
     chromeBrowserAction: chrome.browserAction,
     chromeStorage: chrome.storage,
-    extensionURL: function (path) {
-      return chrome.extension.getURL(path);
-    },
   });
 
   browserExtension.listen();

--- a/tests/background/help-page-test.js
+++ b/tests/background/help-page-test.js
@@ -1,71 +1,58 @@
 import * as errors from '../../src/background/errors';
-import { HelpPage } from '../../src/background/help-page';
+import { HelpPage, $imports } from '../../src/background/help-page';
 
 describe('HelpPage', function () {
-  let fakeBrowserName;
   let fakeChromeTabs;
   let fakeExtensionURL;
   let help;
 
   beforeEach(function () {
-    fakeBrowserName = sinon.stub().returns('chrome');
     fakeChromeTabs = { create: sinon.stub() };
-    fakeExtensionURL = function (path) {
-      return 'CRX_PATH' + path;
-    };
-    help = new HelpPage(fakeChromeTabs, fakeExtensionURL, fakeBrowserName);
+    fakeExtensionURL = path => `chrome://abcd${path}`;
+
+    $imports.$mock({
+      './chrome-api': {
+        chromeAPI: {
+          runtime: { getURL: fakeExtensionURL },
+          tabs: fakeChromeTabs,
+        },
+      },
+    });
+
+    help = new HelpPage();
   });
 
-  describe('.showHelpForError', function () {
-    it('renders the "local-file" page when passed a LocalFileError', function () {
-      help.showHelpForError(
-        { id: 1, index: 1 },
-        new errors.LocalFileError('msg')
-      );
-      assert.called(fakeChromeTabs.create);
-      assert.calledWith(fakeChromeTabs.create, {
-        index: 2,
-        openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#local-file',
-      });
-    });
+  afterEach(() => {
+    $imports.$restore();
+  });
 
-    it('renders the "no-file-access" page when passed a NoFileAccessError', function () {
-      help.showHelpForError(
-        { id: 1, index: 1 },
-        new errors.NoFileAccessError('msg')
-      );
-      assert.called(fakeChromeTabs.create);
-      assert.calledWith(fakeChromeTabs.create, {
-        index: 2,
-        openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#no-file-access',
-      });
-    });
-
-    it('renders the "no-file-access" page when passed a RestrictedProtocolError', function () {
-      help.showHelpForError(
-        { id: 1, index: 1 },
-        new errors.RestrictedProtocolError('msg')
-      );
-      assert.called(fakeChromeTabs.create);
-      assert.calledWith(fakeChromeTabs.create, {
-        index: 2,
-        openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#restricted-protocol',
-      });
-    });
-
-    it('renders the "blocked-site" page when passed a BlockedSiteError', function () {
-      help.showHelpForError(
-        { id: 1, index: 1 },
-        new errors.BlockedSiteError('msg')
-      );
-      assert.called(fakeChromeTabs.create);
-      assert.calledWith(fakeChromeTabs.create, {
-        index: 2,
-        openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#blocked-site',
+  describe('showHelpForError', function () {
+    [
+      {
+        getError: () => new errors.LocalFileError('msg'),
+        helpSection: 'local-file',
+      },
+      {
+        getError: () => new errors.NoFileAccessError('msg'),
+        helpSection: 'no-file-access',
+      },
+      {
+        getError: () => new errors.RestrictedProtocolError('msg'),
+        helpSection: 'restricted-protocol',
+      },
+      {
+        getError: () => new errors.BlockedSiteError('msg'),
+        helpSection: 'blocked-site',
+      },
+    ].forEach(({ getError, helpSection }) => {
+      it('shows appropriate page for the error', () => {
+        help.showHelpForError({ id: 1, index: 1 }, getError());
+        assert.called(fakeChromeTabs.create);
+        assert.calledWith(fakeChromeTabs.create, {
+          index: 2,
+          openerTabId: 1,
+          url: fakeExtensionURL(`/help/index.html?message=msg#${helpSection}`),
+        });
       });
     });
 
@@ -75,63 +62,9 @@ describe('HelpPage', function () {
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
         openerTabId: 1,
-        url: 'CRX_PATH/help/index.html?message=Unexpected%20Error#other-error',
-      });
-    });
-  });
-
-  describe('.showLocalFileHelpPage', function () {
-    it('should load the help page with the "local-file" fragment', function () {
-      help.showLocalFileHelpPage({ id: 1, index: 1 });
-      assert.called(fakeChromeTabs.create);
-      assert.calledWith(fakeChromeTabs.create, {
-        index: 2,
-        openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#local-file',
-      });
-    });
-  });
-
-  describe('.showNoFileAccessHelpPage', function () {
-    it('should load the help page with the "no-file-access" fragment', function () {
-      help.showNoFileAccessHelpPage({ id: 1, index: 1 });
-      assert.called(fakeChromeTabs.create);
-      assert.calledWith(fakeChromeTabs.create, {
-        index: 2,
-        openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#no-file-access',
-      });
-    });
-  });
-
-  describe('.showRestrictedProtocolPage', function () {
-    it('should load the help page with the "restricted-protocol" fragment', function () {
-      help.showRestrictedProtocolPage({ id: 1, index: 1 });
-      assert.called(fakeChromeTabs.create);
-      assert.calledWith(fakeChromeTabs.create, {
-        index: 2,
-        openerTabId: 1,
-        url: 'CRX_PATH/help/index.html#restricted-protocol',
-      });
-    });
-  });
-
-  context('in Firefox', function () {
-    it('does not set the "openerTabId" argument when creating a new tab', function () {
-      fakeBrowserName.returns('firefox');
-      const help = new HelpPage(
-        fakeChromeTabs,
-        fakeExtensionURL,
-        fakeBrowserName
-      );
-      help.showHelpForError(
-        { id: 1, index: 1 },
-        new errors.LocalFileError('msg')
-      );
-      assert.called(fakeChromeTabs.create);
-      assert.calledWith(fakeChromeTabs.create, {
-        index: 2,
-        url: 'CRX_PATH/help/index.html#local-file',
+        url: fakeExtensionURL(
+          '/help/index.html?message=Unexpected+Error#other-error'
+        ),
       });
     });
   });


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/browser-extension/pull/663**

The implementation and tests were rather verbose. This commit rewrites HelpPage
to have the same API (at least, the parts that were actually used) and
functionality but a more succinct implementation and tests.

In the process access to the Chrome APIs has been converted to use the
`chrome-api` module and an obsolete code path for old versions of
Firefox was removed.