### PR TITLE
Promisify can't reject Promise

### DIFF
--- a/src/background/chrome-api.js
+++ b/src/background/chrome-api.js
@@ -52,15 +52,8 @@ export function getChromeAPI(chrome = globalThis.chrome) {
     }
 
     return (...args) => {
-      return new Promise((resolve, reject) => {
-        fn(...args, (/** @type {Result} */ result) => {
-          const lastError = chrome.runtime.lastError;
-          if (lastError) {
-            reject(lastError);
-          } else {
-            resolve(result);
-          }
-        });
+      return new Promise(resolve => {
+        fn(...args, (/** @type {Result} */ result) => resolve(result));
       });
     };
   };


### PR DESCRIPTION
Exceptions in a promisified function can only happened in the execution
of the callback. In our cases, the callback is very simple and will
never raised an exception. Hence the rejection path can be removed.

Related to https://github.com/hypothesis/browser-extension/pull/655#pullrequestreview-757394610.