### PR TITLE
Eliminate side effects from `install.js` import in tests

### DIFF
--- a/src/background/install.js
+++ b/src/background/install.js
@@ -1,10 +1,9 @@
 import HypothesisChromeExtension from './hypothesis-chrome-extension';
 
-/** @type {HypothesisChromeExtension} */
-let browserExtension;
-
-export function init() {
-  browserExtension = new HypothesisChromeExtension({
+// TODO - Convert this module to use `chrome-api.js` to access the Chrome extension.
+// This will need to happen after `HypothesisChromeExtension` is converted.
+export function init(chrome = globalThis.chrome) {
+  const browserExtension = new HypothesisChromeExtension({
     chromeExtension: chrome.extension,
     chromeTabs: chrome.tabs,
     chromeBrowserAction: chrome.browserAction,
@@ -15,56 +14,57 @@ export function init() {
   });
 
   browserExtension.listen();
-}
 
-// @ts-expect-error - `isFakeChrome` is missing from types.
-if (!chrome.isFakeChrome) {
-  init();
-}
-
-if (chrome.runtime.onInstalled) {
-  chrome.runtime.onInstalled.addListener(onInstalled);
-}
-
-// Respond to messages sent by the JavaScript from https://hyp.is.
-// This is how it knows whether the user has this Chrome extension installed.
-if (chrome.runtime.onMessageExternal) {
-  chrome.runtime.onMessageExternal.addListener(function (
-    request,
-    sender,
-    sendResponse
-  ) {
-    if (request.type === 'ping') {
-      sendResponse({ type: 'pong' });
-    }
-  });
-}
-
-if (chrome.runtime.requestUpdateCheck) {
-  chrome.runtime.requestUpdateCheck(function () {
-    chrome.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
-  });
-}
-
-/** @param {chrome.runtime.InstalledDetails} installDetails */
-function onInstalled(installDetails) {
-  // The install reason can be "install", "update", "chrome_update", or
-  // "shared_module_update", see:
-  //
-  //   https://developer.chrome.com/extensions/runtime#type-OnInstalledReason
-  //
-  // If we were installed (rather than updated) then trigger a "firstRun" event,
-  // passing in the details of the installed extension. See:
-  //
-  //   https://developer.chrome.com/extensions/management#method-getSelf
-  //
-  if (installDetails.reason === 'install') {
-    chrome.management.getSelf(browserExtension.firstRun);
+  if (chrome.runtime.onInstalled) {
+    chrome.runtime.onInstalled.addListener(onInstalled);
   }
 
-  browserExtension.install();
+  // Respond to messages sent by the JavaScript from https://hyp.is.
+  // This is how it knows whether the user has this Chrome extension installed.
+  if (chrome.runtime.onMessageExternal) {
+    chrome.runtime.onMessageExternal.addListener(function (
+      request,
+      sender,
+      sendResponse
+    ) {
+      if (request.type === 'ping') {
+        sendResponse({ type: 'pong' });
+      }
+    });
+  }
+
+  if (chrome.runtime.requestUpdateCheck) {
+    chrome.runtime.requestUpdateCheck(function () {
+      chrome.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
+    });
+  }
+
+  /** @param {chrome.runtime.InstalledDetails} installDetails */
+  function onInstalled(installDetails) {
+    // The install reason can be "install", "update", "chrome_update", or
+    // "shared_module_update", see:
+    //
+    //   https://developer.chrome.com/extensions/runtime#type-OnInstalledReason
+    //
+    // If we were installed (rather than updated) then trigger a "firstRun" event,
+    // passing in the details of the installed extension. See:
+    //
+    //   https://developer.chrome.com/extensions/management#method-getSelf
+    //
+    if (installDetails.reason === 'install') {
+      chrome.management.getSelf(browserExtension.firstRun);
+    }
+
+    browserExtension.install();
+  }
+
+  function onUpdateAvailable() {
+    chrome.runtime.reload();
+  }
 }
 
-function onUpdateAvailable() {
-  chrome.runtime.reload();
+// In tests the `chrome` global is not defined so `init` doesn't run until
+// the tests call it. In the extension it is so this runs on import.
+if (typeof chrome !== 'undefined') {
+  init();
 }

--- a/tests/background/install-test.js
+++ b/tests/background/install-test.js
@@ -1,3 +1,5 @@
+import { init, $imports } from '../../src/background/install';
+
 let extension;
 
 function FakeHypothesisChromeExtension(deps) {
@@ -16,14 +18,10 @@ function eventListenerStub() {
 }
 
 describe('install', function () {
-  let origChrome;
   let fakeChrome;
-  let install;
 
   beforeEach(function () {
     fakeChrome = {
-      isFakeChrome: true,
-
       tabs: {},
       browserAction: {},
       storage: {},
@@ -43,22 +41,14 @@ describe('install', function () {
       },
     };
 
-    origChrome = window.chrome;
-    window.chrome = fakeChrome;
-
-    // Defer requiring `common/install` until `window.chrome` is initialized
-    // for the first time because top-level statements in the module depend on
-    // it.
-    install = require('../../src/background/install');
-    install.$imports.$mock({
+    $imports.$mock({
       './hypothesis-chrome-extension': FakeHypothesisChromeExtension,
     });
-    install.init();
+    init(fakeChrome);
   });
 
   afterEach(function () {
-    window.chrome = origChrome;
-    install.$imports.$restore();
+    $imports.$restore();
   });
 
   context('when the extension is installed', function () {


### PR DESCRIPTION
This simplifies the tests by allowing `install.js` to be imported
normally, as the `chrome` fake can be injected before `init` is run.