### PR TITLE
Temporarily disable Firefox extension signing

### DIFF
--- a/tools/deploy
+++ b/tools/deploy
@@ -112,5 +112,8 @@ upload_and_publish_chrome_qa_ext
 echo "Uploading Chrome (prod) extension..."
 upload_chrome_prod_ext
 
-echo "Signing Firefox extensions..."
-sign_firefox_exts
+# 2021-10-05: Disabled because Mozilla's web services are having problems and
+# timing out when signing the extension.
+#
+# echo "Signing Firefox extensions..."
+# sign_firefox_exts


### PR DESCRIPTION
It seems that there is an ongoing problem with either the web-ext tool
or Mozilla's services.

Since we're not actively shipping/supporting the Firefox extension, just
disable signing for the moment.

Example error output from Jenkins:

```
Signing Firefox extensions...
Waiting for Firefox QA signing to complete...
Applying config file: ./package.json
Building web extension from
/data/jenkins/workspace/browser-extension_master/dist/firefox-qa
Validation results:
https://addons.mozilla.org/en-US/developers/upload/1ad32e91ce4f432ba67ba18b554853c5

Error: Signing took too long to complete; last status:
{"guid":"{b441de5f-18e6-40ad-a8c2-f1bd2d42cb01}","active":false,"automated_signing":true,"url":"https://addons.mozilla.org/api/v4/addons/%7Bb441de5f-18e6-40ad-a8c2-f1bd2d42cb01%7D/versions/1.879.0.6/uploads/1ad32e91ce4f432ba67ba18b554853c5/","files":[{"download_url":"https://addons.mozilla.org/api/v4/file/3849295/hypothesis_web_pdf_annotation_stage-1.879.0.6-an+fx.xpi","hash":"sha256:c239b474730deec8c978078935046e5fc697cda7d4cee3c3a9b3e4e334d0120e","signed":false}],"passed_review":null,"pk":"1ad...
    at Timeout._onTimeout
    (/data/jenkins/workspace/browser-extension_master/node_modules/sign-addon/dist/webpack:/sign-addon/src/amo-client.js:326:11)
        at listOnTimeout (internal/timers.js:557:17)
            at processTimers (internal/timers.js:500:7)
```