### PR TITLE
Convert `background/install.js` to use Chrome API wrapper

### DIFF
--- a/src/background/chrome-api.js
+++ b/src/background/chrome-api.js
@@ -93,8 +93,21 @@ export function getChromeAPI(chrome = globalThis.chrome) {
       ),
     },
 
+    management: {
+      getSelf: promisify(chrome.management.getSelf),
+    },
+
     runtime: {
       getURL: chrome.runtime.getURL,
+      onMessageExternal: chrome.runtime.onMessageExternal,
+      onInstalled: chrome.runtime.onInstalled,
+      onUpdateAvailable: chrome.runtime.onUpdateAvailable,
+      reload: chrome.runtime.reload,
+
+      // Firefox (as of v92) does not support `requestUpdateCheck`.
+      requestUpdateCheck: chrome.runtime.requestUpdateCheck
+        ? promisify(chrome.runtime.requestUpdateCheck)
+        : null,
     },
 
     permissions: {

--- a/src/background/hypothesis-chrome-extension.js
+++ b/src/background/hypothesis-chrome-extension.js
@@ -37,7 +37,8 @@ export default function HypothesisChromeExtension() {
 
   restoreSavedTabState();
 
-  /* Sets up the extension and binds event listeners. Requires a window
+  /**
+   * Sets up the extension and binds event listeners. Requires a window
    * object to be passed so that it can listen for localStorage events.
    */
   this.listen = function () {
@@ -57,7 +58,8 @@ export default function HypothesisChromeExtension() {
     chromeAPI.tabs.onRemoved.addListener(onTabRemoved);
   };
 
-  /* A method that can be used to setup the extension on existing tabs
+  /**
+   * A method that can be used to setup the extension on existing tabs
    * when the extension is re-installed.
    */
   this.install = async () => {

--- a/src/background/install.js
+++ b/src/background/install.js
@@ -1,57 +1,36 @@
+import { chromeAPI } from './chrome-api';
 import HypothesisChromeExtension from './hypothesis-chrome-extension';
 
-// TODO - Convert this module to use `chrome-api.js` to access the Chrome extension.
-export function init(chrome = globalThis.chrome) {
+export async function init() {
   const browserExtension = new HypothesisChromeExtension();
 
   browserExtension.listen();
 
-  if (chrome.runtime.onInstalled) {
-    chrome.runtime.onInstalled.addListener(onInstalled);
-  }
+  chromeAPI.runtime.onInstalled.addListener(async installDetails => {
+    // Check whether this is the inital installation or an update of an existing
+    // installation.
+    if (installDetails.reason === 'install') {
+      const extensionInfo = await chromeAPI.management.getSelf();
+      browserExtension.firstRun(extensionInfo);
+    }
+    browserExtension.install();
+  });
 
   // Respond to messages sent by the JavaScript from https://hyp.is.
   // This is how it knows whether the user has this Chrome extension installed.
-  if (chrome.runtime.onMessageExternal) {
-    chrome.runtime.onMessageExternal.addListener(function (
-      request,
-      sender,
-      sendResponse
-    ) {
+  chromeAPI.runtime.onMessageExternal.addListener(
+    (request, sender, sendResponse) => {
       if (request.type === 'ping') {
         sendResponse({ type: 'pong' });
       }
-    });
-  }
-
-  if (chrome.runtime.requestUpdateCheck) {
-    chrome.runtime.requestUpdateCheck(function () {
-      chrome.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
-    });
-  }
-
-  /** @param {chrome.runtime.InstalledDetails} installDetails */
-  function onInstalled(installDetails) {
-    // The install reason can be "install", "update", "chrome_update", or
-    // "shared_module_update", see:
-    //
-    //   https://developer.chrome.com/extensions/runtime#type-OnInstalledReason
-    //
-    // If we were installed (rather than updated) then trigger a "firstRun" event,
-    // passing in the details of the installed extension. See:
-    //
-    //   https://developer.chrome.com/extensions/management#method-getSelf
-    //
-    if (installDetails.reason === 'install') {
-      chrome.management.getSelf(browserExtension.firstRun);
     }
+  );
 
-    browserExtension.install();
-  }
-
-  function onUpdateAvailable() {
-    chrome.runtime.reload();
-  }
+  chromeAPI.runtime.requestUpdateCheck?.().then(() => {
+    chromeAPI.runtime.onUpdateAvailable.addListener(() =>
+      chromeAPI.runtime.reload()
+    );
+  });
 }
 
 // In tests the `chrome` global is not defined so `init` doesn't run until

--- a/tests/background/chrome-api-test.js
+++ b/tests/background/chrome-api-test.js
@@ -21,6 +21,10 @@ describe('getChromeAPI', () => {
         isAllowedFileSchemeAccess: sinon.stub(),
       },
 
+      management: {
+        getSelf: sinon.stub(),
+      },
+
       runtime: {
         lastError: null,
         getURL: sinon.stub(),


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/browser-extension/pull/678**

Convert install.js to use the promise-based Chrome API wrapper from
chrome-api.js.

In the process some simplifications were made to the code:

 - Comments that repeated information available in the Chrome API types
   (via @types/chrome) have been simplified or eliminated

 - Unnecessary checks for the availability of APIs have been removed.
   The only remaining check that is still required is `requestUpdateCheck`.