### PR TITLE
Show original source locations in test error stacktraces

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon": "^1.0.5",
+    "karma-source-map-support": "^1.4.0",
     "mocha": "^9.1.2",
     "mustache": "^4.2.0",
     "prettier": "2.4.1",

--- a/rollup-tests.config.js
+++ b/rollup-tests.config.js
@@ -11,6 +11,7 @@ export default {
     file: 'build/tests.bundle.js',
     format: 'iife',
     name: 'testsBundle', // This just exists to suppress a build warning.
+    sourcemap: true,
   },
   treeshake: false, // Disabled for build performance
   plugins: [

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -41,10 +41,13 @@ module.exports = function (config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha', 'chai', 'sinon'],
+    frameworks: ['mocha', 'chai', 'sinon', 'source-map-support'],
 
     // list of files / patterns to load in the browser
-    files: ['../build/tests.bundle.js'],
+    files: [
+      '../build/tests.bundle.js',
+      { pattern: '../build/*.js.map', included: false },
+    ],
 
     // list of files to exclude
     exclude: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5199,6 +5199,13 @@ karma-sinon@^1.0.5:
   resolved "https://registry.yarnpkg.com/karma-sinon/-/karma-sinon-1.0.5.tgz#4e3443f2830fdecff624d3747163f1217daa2a9a"
   integrity sha1-TjRD8oMP3s/2JNN0cWPxIX2qKpo=
 
+karma-source-map-support@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/karma-source-map-support/-/karma-source-map-support-1.4.0.tgz#58526ceccf7e8730e56effd97a4de8d712ac0d6b"
+  integrity sha512-RsBECncGO17KAoJCYXjv+ckIz+Ii9NCi+9enk+rq6XC81ezYkb4/RHE6CTXdA7IOJqoF3wcaLfVG0CPmE5ca6A==
+  dependencies:
+    source-map-support "^0.5.5"
+
 karma@^6.3.4:
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/karma/-/karma-6.3.4.tgz#359899d3aab3d6b918ea0f57046fd2a6b68565e6"
@@ -7315,6 +7322,14 @@ source-map-support@0.5.19, source-map-support@~0.5.4:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@^0.5.5:
+  version "0.5.20"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.20.tgz#12166089f8f5e5e8c56926b377633392dd2cb6c9"
+  integrity sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"


### PR DESCRIPTION
Use the karma-source-map-support package to make assert error stacktraces
reported by Karma show the original source location instead of the
location within the test bundle.

karma-source-map-support is a simple package which loads the
source-map-support package in the browser [1]. This package is
Chrome-specific. In non-Chrome browsers the tests can still run but will
show the location in the test bundle.

1. Modify rollup-tests.config.js to generate sourcemaps
2. Modify karma.config.js to serve the sourcemaps
3. Use karma-source-map-plugin to use the sourcemaps in the browser running the tests

[1] https://github.com/evanw/node-source-map-support#browser-support

---

Example of a test failure before: 

```
  SidebarInjector
    .injectIntoTab
      ✖ throws if tab does not have ID or URL
        Chrome Headless 93.0.4577.0 (Mac OS 10.15.7)
      AssertionError: expected [Error: Tab is missing ID or URL] to be an instance of URL

      + expected - actual


    at Context.<anonymous> (/Users/robert/hypothesis/browser-extension/build/tests.bundle.js:20895:17)
```

Example of a test failure after:

```
  SidebarInjector
    .injectIntoTab
      ✖ throws if tab does not have ID or URL
        Chrome Headless 93.0.4577.0 (Mac OS 10.15.7)
      AssertionError: expected [Error: Tab is missing ID or URL] to be an instance of URL

      + expected - actual


    at Context.<anonymous> (/Users/robert/hypothesis/browser-extension/tests/background/sidebar-injector-test.js:178:16)
```