### PR TITLE
Remove references to Travis and other obsolete test configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![BSD licensed](https://img.shields.io/badge/license-BSD-blue.svg)][license]
 
-[travis]: https://travis-ci.org/hypothesis/browser-extension
-[irc]: https://www.irccloud.com/invite?channel=%23hypothes.is&hostname=irc.freenode.net&port=6667&ssl=1
 [license]: https://github.com/hypothesis/browser-extension/blob/master/LICENSE
 
 The Hypothesis browser extensions allow you to annotate web documents using your

--- a/rollup-tests.config.js
+++ b/rollup-tests.config.js
@@ -9,8 +9,7 @@ export default {
   input: ['tests/bootstrap.js', ...glob.sync('tests/**/*-test.js')],
   output: {
     file: 'build/tests.bundle.js',
-    format: 'iife',
-    name: 'testsBundle', // This just exists to suppress a build warning.
+    format: 'es',
     sourcemap: true,
   },
   treeshake: false, // Disabled for build performance

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -6,22 +6,12 @@ const path = require('path');
 
 let chromeFlags = [];
 
-if (process.version.startsWith('v14.')) {
-  // See https://github.com/puppeteer/puppeteer/issues/5719
-  console.warn(
-    'Using system Chrome instead of Puppeteer due to issue with Node 14'
-  );
-} else {
-  process.env.CHROME_BIN = require('puppeteer').executablePath();
-}
-
-// On Travis and in Docker, the tests run as root, so the sandbox must be
-// disabled.
-if (process.env.TRAVIS || process.env.RUNNING_IN_DOCKER) {
-  chromeFlags = ['--no-sandbox'];
-}
+process.env.CHROME_BIN = require('puppeteer').executablePath();
 
 if (process.env.RUNNING_IN_DOCKER) {
+  // In Docker, the tests run as root, so the sandbox must be disabled.
+  chromeFlags.push('--no-sandbox');
+
   // Disable `/dev/shm` usage as this can cause Chrome to fail to load large
   // HTML pages, such as the one Karma creates with all the tests loaded.
   //
@@ -45,12 +35,9 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      '../build/tests.bundle.js',
+      { pattern: '../build/tests.bundle.js', type: 'module' },
       { pattern: '../build/*.js.map', included: false },
     ],
-
-    // list of files to exclude
-    exclude: [],
 
     mochaReporter: {
       // Display a helpful diff when comparing complex objects

--- a/tools/chrome-webstore-refresh-token
+++ b/tools/chrome-webstore-refresh-token
@@ -17,7 +17,7 @@ set -eu
 #    ./tools/chrome-webstore-refresh-token $AUTH_CODE
 #
 # 3. Copy the 'refresh_token' value and update the corresponding credentials in
-#    Jenkins (see `Jenkinsfile`) and Travis.
+#    Jenkins (see `Jenkinsfile`).
 
 AUTH_CODE=$1
 


### PR DESCRIPTION
We don't use Travis for CI any more.

 - Remove references to Travis from README and Karma config

 - Remove workaround for Node v14 in Karma config. The problem has been
   fixed and Node v16 is currently the LTS version.

 - Build and load tests as an ES module. This matches how our other
   projects work and eliminates a workaround in the Rollup config