### PR TITLE
Correct regex pattern in the replace

### DIFF
--- a/src/background/settings.js
+++ b/src/background/settings.js
@@ -21,5 +21,5 @@ export default /** @type {Settings} */ ({
   ...settings,
 
   // Ensure API url does not end with '/'
-  apiUrl: settings.apiUrl.replace(/\/^/, ''),
+  apiUrl: settings.apiUrl.replace(/\/$/, ''),
 });


### PR DESCRIPTION
I believe the intention is to strip out the last `/` character, if any
(as the comment say).