### PR TITLE
Add wrappers around extension APIs for executing scripts

### DIFF
--- a/src/background/chrome-api.js
+++ b/src/background/chrome-api.js
@@ -179,7 +179,7 @@ function codeStringForFunctionCall(func, args) {
  * @param {object} options
  *   @param {number} options.tabId
  *   @param {number} [options.frameId]
- *   @param {string} options.file
+ *   @param {string} options.file - Path to the script within the extension
  * @return {Promise<unknown>}
  */
 export async function executeScript(

--- a/tests/background/chrome-api-test.js
+++ b/tests/background/chrome-api-test.js
@@ -1,130 +1,229 @@
-import { getChromeAPI } from '../../src/background/chrome-api';
+import {
+  getChromeAPI,
+  executeFunction,
+  executeScript,
+} from '../../src/background/chrome-api';
 
-describe('getChromeAPI', () => {
-  function fakeListener() {
-    return { addListener: sinon.stub() };
-  }
+// Helper defined at top level to simplify its stringified representation.
+function testFunc(a, b) {
+  return a + b;
+}
 
-  let fakeChrome;
+describe('chrome-api', () => {
+  describe('getChromeAPI', () => {
+    function fakeListener() {
+      return { addListener: sinon.stub() };
+    }
 
-  beforeEach(() => {
-    fakeChrome = {
-      browserAction: {
-        onClicked: fakeListener(),
-        setBadgeBackgroundColor: sinon.stub(),
-        setBadgeText: sinon.stub(),
-        setIcon: sinon.stub(),
-        setTitle: sinon.stub(),
-      },
+    let fakeChrome;
 
-      extension: {
-        isAllowedFileSchemeAccess: sinon.stub(),
-      },
-
-      management: {
-        getSelf: sinon.stub(),
-      },
-
-      runtime: {
-        lastError: null,
-        getURL: sinon.stub(),
-      },
-
-      permissions: {
-        getAll: sinon.stub(),
-        request: sinon.stub(),
-      },
-
-      tabs: {
-        create: sinon.stub(),
-        get: sinon.stub(),
-        executeScript: sinon.stub(),
-        onCreated: fakeListener(),
-        onReplaced: fakeListener(),
-        onRemoved: fakeListener(),
-        onUpdated: fakeListener(),
-        query: sinon.stub(),
-        update: sinon.stub(),
-      },
-
-      storage: {
-        sync: {
-          get: sinon.stub(),
+    beforeEach(() => {
+      fakeChrome = {
+        browserAction: {
+          onClicked: fakeListener(),
+          setBadgeBackgroundColor: sinon.stub(),
+          setBadgeText: sinon.stub(),
+          setIcon: sinon.stub(),
+          setTitle: sinon.stub(),
         },
-      },
-    };
-  });
 
-  it('wrapped methods call browser API', async () => {
-    const syncAPIs = new Set([fakeChrome.runtime.getURL]);
+        extension: {
+          isAllowedFileSchemeAccess: sinon.stub(),
+        },
 
-    const chromeAPI = getChromeAPI(fakeChrome);
+        management: {
+          getSelf: sinon.stub(),
+        },
 
-    for (let namespace of Object.keys(fakeChrome)) {
-      for (let methodName of Object.keys(fakeChrome[namespace])) {
-        const method = fakeChrome[namespace][methodName];
-        if (typeof method !== 'function') {
-          // Skip listeners `on<Event>` and nested namespaces (eg. `storage.sync.get`).
-          continue;
-        }
+        runtime: {
+          lastError: null,
+          getURL: sinon.stub(),
+        },
 
-        const arg = {};
-        let result = chromeAPI[namespace][methodName](arg);
-        assert.calledWith(method, arg);
+        permissions: {
+          getAll: sinon.stub(),
+          request: sinon.stub(),
+        },
 
-        if (!syncAPIs.has(method)) {
-          const expectedResult = {};
-          method.yield(expectedResult);
-          assert.equal(await result, expectedResult);
+        tabs: {
+          create: sinon.stub(),
+          get: sinon.stub(),
+          executeScript: sinon.stub(),
+          onCreated: fakeListener(),
+          onReplaced: fakeListener(),
+          onRemoved: fakeListener(),
+          onUpdated: fakeListener(),
+          query: sinon.stub(),
+          update: sinon.stub(),
+        },
+
+        storage: {
+          sync: {
+            get: sinon.stub(),
+          },
+        },
+      };
+    });
+
+    it('wrapped methods call browser API', async () => {
+      const syncAPIs = new Set([fakeChrome.runtime.getURL]);
+
+      const chromeAPI = getChromeAPI(fakeChrome);
+
+      for (let namespace of Object.keys(fakeChrome)) {
+        for (let methodName of Object.keys(fakeChrome[namespace])) {
+          const method = fakeChrome[namespace][methodName];
+          if (typeof method !== 'function') {
+            // Skip listeners `on<Event>` and nested namespaces (eg. `storage.sync.get`).
+            continue;
+          }
+
+          const arg = {};
+          let result = chromeAPI[namespace][methodName](arg);
+          assert.calledWith(method, arg);
+
+          if (!syncAPIs.has(method)) {
+            const expectedResult = {};
+            method.yield(expectedResult);
+            assert.equal(await result, expectedResult);
+          }
         }
       }
-    }
-  });
+    });
 
-  it('wrapped methods reject if an error occurs', async () => {
-    const chromeAPI = getChromeAPI(fakeChrome);
-
-    fakeChrome.runtime.lastError = new Error('Something went wrong');
-    fakeChrome.tabs.get.yields(null);
-
-    let error;
-    try {
-      await chromeAPI.tabs.get(1);
-    } catch (e) {
-      error = e;
-    }
-
-    assert.equal(error, fakeChrome.runtime.lastError);
-  });
-
-  describe('APIs that require optional permissions', () => {
-    it('rejects if permission has not been granted', async () => {
+    it('wrapped methods reject if an error occurs', async () => {
       const chromeAPI = getChromeAPI(fakeChrome);
+
+      fakeChrome.runtime.lastError = new Error('Something went wrong');
+      fakeChrome.tabs.get.yields(null);
 
       let error;
       try {
-        await chromeAPI.webNavigation.getAllFrames();
+        await chromeAPI.tabs.get(1);
       } catch (e) {
         error = e;
       }
 
-      assert.ok(error);
+      assert.equal(error, fakeChrome.runtime.lastError);
     });
 
-    it('succeeds if permission has been granted', async () => {
-      const chromeAPI = getChromeAPI(fakeChrome);
+    describe('APIs that require optional permissions', () => {
+      it('rejects if permission has not been granted', async () => {
+        const chromeAPI = getChromeAPI(fakeChrome);
 
-      const frames = [];
+        let error;
+        try {
+          await chromeAPI.webNavigation.getAllFrames();
+        } catch (e) {
+          error = e;
+        }
 
-      // Simulate the "webNavigation" permission being granted, which will
-      // make the `chrome.webNavigation` property accessible.
-      fakeChrome.webNavigation = {
-        getAllFrames: sinon.stub().yields(frames),
+        assert.ok(error);
+      });
+
+      it('succeeds if permission has been granted', async () => {
+        const chromeAPI = getChromeAPI(fakeChrome);
+
+        const frames = [];
+
+        // Simulate the "webNavigation" permission being granted, which will
+        // make the `chrome.webNavigation` property accessible.
+        fakeChrome.webNavigation = {
+          getAllFrames: sinon.stub().yields(frames),
+        };
+
+        const actualFrames = await chromeAPI.webNavigation.getAllFrames();
+
+        assert.equal(actualFrames, frames);
+      });
+    });
+  });
+
+  describe('executeFunction', () => {
+    let fakeChromeAPI;
+
+    beforeEach(() => {
+      fakeChromeAPI = {
+        tabs: {
+          executeScript: sinon.stub().resolves(['result']),
+        },
       };
+    });
 
-      const actualFrames = await chromeAPI.webNavigation.getAllFrames();
+    it('calls `chrome.tabs.executeScript` with stringified source', async () => {
+      const result = await executeFunction(
+        {
+          tabId: 1,
+          func: testFunc,
+          args: [1, 2],
+        },
+        fakeChromeAPI
+      );
+      assert.calledWith(fakeChromeAPI.tabs.executeScript, 1, {
+        frameId: undefined,
+        code: '(function testFunc(a, b) {\n  return a + b;\n})(1,2)',
+      });
+      assert.equal(result, 'result');
+    });
 
-      assert.equal(actualFrames, frames);
+    it('sets frame ID if provided', async () => {
+      const result = await executeFunction(
+        {
+          tabId: 1,
+          frameId: 2,
+          func: testFunc,
+          args: [1, 2],
+        },
+        fakeChromeAPI
+      );
+      assert.calledWith(fakeChromeAPI.tabs.executeScript, 1, {
+        frameId: 2,
+        code: '(function testFunc(a, b) {\n  return a + b;\n})(1,2)',
+      });
+      assert.equal(result, 'result');
+    });
+  });
+
+  describe('executeScript', () => {
+    let fakeChromeAPI;
+
+    beforeEach(() => {
+      fakeChromeAPI = {
+        tabs: {
+          executeScript: sinon.stub().resolves(['result']),
+        },
+      };
+    });
+
+    it('calls `chrome.tabs.executeScript` with files', async () => {
+      const result = await executeScript(
+        {
+          tabId: 1,
+          file: 'foo.js',
+        },
+        fakeChromeAPI
+      );
+      assert.calledWith(fakeChromeAPI.tabs.executeScript, 1, {
+        frameId: undefined,
+        file: 'foo.js',
+      });
+      assert.equal(result, 'result');
+    });
+
+    it('sets frame ID if provided', async () => {
+      const result = await executeScript(
+        {
+          tabId: 1,
+          frameId: 2,
+          file: 'foo.js',
+        },
+        fakeChromeAPI
+      );
+      assert.calledWith(fakeChromeAPI.tabs.executeScript, 1, {
+        frameId: 2,
+        file: 'foo.js',
+      });
+      assert.deepEqual(result, 'result');
     });
   });
 });

--- a/tests/background/sidebar-injector-test.js
+++ b/tests/background/sidebar-injector-test.js
@@ -76,6 +76,7 @@ describe('SidebarInjector', function () {
       installedURL: EXTENSION_BASE_URL + '/client/app.html',
     };
 
+    // Simulate running a self-contained function in the tab.
     fakeExecuteFunction = sinon.spy(async ({ func, args }) => {
       if (contentFrame) {
         const codeStr = `(${func})(${args
@@ -90,6 +91,7 @@ describe('SidebarInjector', function () {
       }
     });
 
+    // Simulate running a JS script in the tab.
     fakeExecuteScript = sinon.spy(async ({ file }) => {
       if (file.match(/boot/)) {
         return embedScriptReturnValue;


### PR DESCRIPTION
One of the major changes between Manifest V2 and Manifest V3 is the API for executing scripts in a tab. Add `executeFunction` and `executeScript` wrappers in `chrome-api.js` which wrap the extension APIs for script execution provided by the current browser. Currently this calls the `chrome.tabs.executeScript` API from Manifest V2 / WebExtensions. In future it will call `chrome.scripting.executeScript` in browsers that support Manifest V3.

As well as abstracting over browser differences, these wrappers also enable better typing and a simpler interface for other parts of the extension. The Manifest V3 APIs for executing a script or function in a tab are, in particular, a bit cumbersome because they supports multiple files and frame IDs even though we only ever pass one, and the `tabId` property is wrapped inside a `target` object.

The changes in `chrome-api-test.js` include a lot of whitespace changes, so I suggest viewing the ignore-whitespace diff.

Part of https://github.com/hypothesis/browser-extension/issues/622.