### PR TITLE
Don't request "webNavigation" permission if we already have it

### DIFF
--- a/src/background/chrome-api.js
+++ b/src/background/chrome-api.js
@@ -111,6 +111,7 @@ export function getChromeAPI(chrome = globalThis.chrome) {
     },
 
     permissions: {
+      getAll: promisify(chrome.permissions.getAll),
       request: promisify(chrome.permissions.request),
     },
 

--- a/tests/background/chrome-api-test.js
+++ b/tests/background/chrome-api-test.js
@@ -31,6 +31,7 @@ describe('getChromeAPI', () => {
       },
 
       permissions: {
+        getAll: sinon.stub(),
         request: sinon.stub(),
       },
 

--- a/tests/background/sidebar-injector-test.js
+++ b/tests/background/sidebar-injector-test.js
@@ -103,6 +103,11 @@ describe('SidebarInjector', function () {
       },
 
       permissions: {
+        getAll: sinon.stub().callsFake(async () => {
+          return {
+            permissions: [...permissions],
+          };
+        }),
         request: sinon.stub().callsFake(async request => {
           const allowed = request.permissions.every(perm =>
             allowedPermissions.includes(perm)
@@ -271,6 +276,19 @@ describe('SidebarInjector', function () {
           file: '/client/build/boot.js',
           frameId: vitalSourceFrames.reader.frameId,
         });
+      });
+
+      it('requests "webNavigation" permission if not present', async () => {
+        await injectClient();
+        assert.calledWith(fakeChromeAPI.permissions.request, {
+          permissions: ['webNavigation'],
+        });
+      });
+
+      it('does not request "webNavigation" permission if already granted', async () => {
+        permissions.add('webNavigation');
+        await injectClient();
+        assert.notCalled(fakeChromeAPI.permissions.request);
       });
 
       it('rejects if "webNavigation" permission is denied', async () => {


### PR DESCRIPTION
Calls to inject the client into the VitalSource viewer happen in two
ways:

 1. Manually, in response to a user activating the extension
 2. Automatically, when the browser attempts to re-inject Hypothesis
    after a potential navigation ("potential" because the extension
    doesn't know if the tab URL changed as a result of a client-side URL
    update or a server-side page change).

In scenario (2) the tab would always be flagged as having an error
because the `chrome.permissions.request` API fails if called outside of
a user gesture, even if the extension already has the permission.

Fix the issue by checking for the permission using
`chrome.permissions.getAll`, which does not require a user gesture, and
then only requesting if if needed.

---

**Testing:**

Only a book in VitalSource on this branch and activate the extension. Navigate forwards and backwards in the book and you should see that the extension's badge no longer shows a "!" after navigations.