### PR TITLE
Format JS files in tools/ folder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
+.yalc/
+build/
+coverage/
 src/vendor/

--- a/Makefile
+++ b/Makefile
@@ -90,11 +90,11 @@ lint: node_modules/.uptodate build/settings.json
 
 .PHONY: checkformatting
 checkformatting: node_modules/.uptodate
-	$(PRETTIER) --check 'src/**/*.js' 'tests/**/*.js'
+	$(PRETTIER) --check '**/*.js'
 
 .PHONY: format
 format: node_modules/.uptodate
-	$(PRETTIER) --list-different --write '{src, tests}/**/*.js' '*.config.js'
+	$(PRETTIER) --list-different --write '**/*.js'
 
 .PHONY: test
 test: node_modules/.uptodate

--- a/tools/template-context-app.js
+++ b/tools/template-context-app.js
@@ -39,6 +39,8 @@ if (process.argv.length !== 3) {
 
 const settings = require(path.join(process.cwd(), process.argv[2]));
 
-console.log(JSON.stringify({
-  'settings': JSON.stringify(appSettings(settings)),
-}));
+console.log(
+  JSON.stringify({
+    settings: JSON.stringify(appSettings(settings)),
+  })
+);


### PR DESCRIPTION
Change the Prettier config to format all JS files except for ignored
directories. This ensures that all files in the root dir and tools/ are
formatted.