### PR TITLE
Remove `websocketUrl` setting

### DIFF
--- a/settings/chrome-dev.json
+++ b/settings/chrome-dev.json
@@ -5,7 +5,6 @@
   "authDomain": "localhost",
   "bouncerUrl": "http://localhost:8000/",
   "serviceUrl": "http://localhost:5000/",
-  "websocketUrl": "ws://localhost:5001/ws",
 
   "browserIsChrome": true,
   "appType": "chrome-extension"

--- a/settings/chrome-prod.json
+++ b/settings/chrome-prod.json
@@ -7,7 +7,6 @@
   "authDomain": "hypothes.is",
   "bouncerUrl": "https://hyp.is/",
   "serviceUrl": "https://hypothes.is/",
-  "websocketUrl": "wss://hypothes.is/ws",
 
   "oauthClientId": "fd23fe2e-7792-11e7-8e16-23e47a1799d4",
 

--- a/settings/chrome-qa.json
+++ b/settings/chrome-qa.json
@@ -6,7 +6,6 @@
   "authDomain": "hypothes.is",
   "bouncerUrl": "https://qa.hyp.is/",
   "serviceUrl": "https://qa.hypothes.is/",
-  "websocketUrl": "wss://qa.hypothes.is/ws",
 
   "oauthClientId": "da545114-7792-11e7-90b4-b35c52774c7d",
 

--- a/settings/firefox-dev.json
+++ b/settings/firefox-dev.json
@@ -4,7 +4,6 @@
   "apiUrl": "http://localhost:5000/api/",
   "authDomain": "localhost",
   "serviceUrl": "http://localhost:5000/",
-  "websocketUrl": "ws://localhost:5001/ws",
 
   "browserIsFirefox": true,
   "appType": "firefox-extension"

--- a/settings/firefox-prod.json
+++ b/settings/firefox-prod.json
@@ -5,7 +5,6 @@
   "authDomain": "hypothes.is",
   "bouncerUrl": "https://hyp.is/",
   "serviceUrl": "https://hypothes.is/",
-  "websocketUrl": "wss://hypothes.is/ws",
 
   "oauthClientId": "7fb28342-7793-11e7-90b5-7fed4053f592",
 

--- a/settings/firefox-qa.json
+++ b/settings/firefox-qa.json
@@ -5,7 +5,6 @@
   "authDomain": "hypothes.is",
   "bouncerUrl": "https://qa.hyp.is/",
   "serviceUrl": "https://qa.hypothes.is/",
-  "websocketUrl": "wss://qa.hypothes.is/ws",
 
   "oauthClientId": "92b42e3c-7793-11e7-8e17-cb2151436a1f",
 

--- a/tools/template-context-app.js
+++ b/tools/template-context-app.js
@@ -17,18 +17,18 @@ function appSettings(settings) {
   result.serviceUrl = settings.serviceUrl;
   result.release = settings.version;
   result.appType = settings.appType || '';
-  if (settings.websocketUrl) {
-    result.websocketUrl = settings.websocketUrl;
-  }
+
   if (settings.sentryPublicDSN) {
     result.raven = {
       dsn: settings.sentryPublicDSN,
       release: settings.version,
     };
   }
+
   if (settings.oauthClientId) {
     result.oauthClientId = settings.oauthClientId;
   }
+
   return result;
 }
 


### PR DESCRIPTION
The client now obtains this URL from the `/api/links` endpoint.  See https://github.com/hypothesis/h/pull/7254 and
https://github.com/hypothesis/client/pull/4148.

This should not be merged until https://github.com/hypothesis/client/pull/4148 is deployed. (_Update: This is now done._)