### PR TITLE
Disable extension on LMS assignments

### DIFF
--- a/src/background/errors.js
+++ b/src/background/errors.js
@@ -32,6 +32,8 @@ const IGNORED_ERRORS = [
   // Attempts to access pages for which Chrome does not allow scripting
   /Cannot access contents of.*/,
   /The extensions gallery cannot be scripted/,
+  // The extension is blocked on LMSs
+  /Hypothesis extension can't be used on learning platform assignments/,
 ];
 
 /**

--- a/src/help/index.html
+++ b/src/help/index.html
@@ -103,7 +103,7 @@
       </section>
       <section id="blocked-site" class="help-item">
         <img class="help-item__icon" src="sad-annotation.svg" />
-        <h1 class="help-item__heading">We’re sorry, Hypothesis doesn't work on this site yet.</h1>
+        <h1 class="help-item__heading">We’re sorry, Hypothesis doesn't work on this site.</h1>
       </section>
       <section id="other-error" class="help-item">
         <img class="help-item__icon" src="sad-annotation.svg" />

--- a/tests/background/sidebar-injector-test.js
+++ b/tests/background/sidebar-injector-test.js
@@ -357,6 +357,24 @@ describe('SidebarInjector', function () {
       });
     });
 
+    describe('when viewing a LMS assignment on a new window', () => {
+      it("doesn't inject Hypothesis client", async () => {
+        let error;
+
+        try {
+          await injector.injectIntoTab({
+            id: 1,
+            url: 'http://qa-lms.hypothes.is/blah',
+          });
+        } catch (err) {
+          error = err;
+        }
+
+        assert.instanceOf(error, errors.BlockedSiteError);
+        assert.notCalled(fakeExecuteScript);
+      });
+    });
+
     describe('when viewing a local PDF', function () {
       describe('when file access is enabled', function () {
         it('loads the PDFjs viewer', function () {


### PR DESCRIPTION
LMS assignments can be opened on a new window. When that option is used
the URL of the window has an origin `[*]lms.hypothesis.is`.

![image](https://user-images.githubusercontent.com/8555781/154047301-54163668-729f-4de4-a7ad-f6b2abe3d9cc.png)


If the the document's URL matches `[*]lms.hypothes.is` we disable the
browser extension and show a warning message (on second click).


![Screenshot 2022-02-14 at 17 22 18](https://user-images.githubusercontent.com/8555781/154046690-e62370c9-d521-4a80-a9f2-9c9a35cdd46b.png)


Closes https://github.com/hypothesis/product-backlog/issues/1310