### PR TITLE
Don't track custom settings JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ coverage/
 
 # The client uses yarn rather than npm to manage the lockfile.
 package-lock.json
+
+# Local settings for dev and test
+settings/*custom*.json

--- a/docs/building.md
+++ b/docs/building.md
@@ -34,7 +34,8 @@ This, for example, will build a production extension: one that talks to the main
 
 > Note:
 > It may be convenient to create a new, untracked config file
-> based on `chrome-dev.json` to maintain your settings
+> based on `chrome-dev.json` to maintain your settings. Any settings JSON file
+> in the `settings` directory with `custom` in the name will be git-ignored
 > (here called `custom.json`):
 >
 >       $ make build SETTINGS_FILE=settings/custom.json


### PR DESCRIPTION
Grabbing at anything that makes the local-build workflow even incrementally easier for devs...

For ease of development workflow, ignore any JSON settings files with "custom" in the filename.