### PR TITLE
make setting the oauth client id for dev environments easier to find

### DIFF
--- a/settings/chrome-dev.json
+++ b/settings/chrome-dev.json
@@ -6,6 +6,8 @@
   "bouncerUrl": "http://localhost:8000/",
   "serviceUrl": "http://localhost:5000/",
 
+  "oauthClientId": "DEV_UNDEFINED_CLIENT",
+
   "browserIsChrome": true,
   "appType": "chrome-extension"
 }

--- a/settings/firefox-dev.json
+++ b/settings/firefox-dev.json
@@ -5,6 +5,8 @@
   "authDomain": "localhost",
   "serviceUrl": "http://localhost:5000/",
 
+  "oauthClientId": "DEV_UNDEFINED_CLIENT",
+
   "browserIsFirefox": true,
   "appType": "firefox-extension"
 }


### PR DESCRIPTION
Make setting the oauth client id for dev environments easier to find by setting it to a unique string that is easy to search for.