### PR TITLE
Update ESLint config, remove obsolete override

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,8 +2,5 @@
   "extends": "hypothesis",
   "globals": {
     "chrome": false
-  },
-  "rules": {
-    "indent": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chrome-webstore-upload-cli": "^2.1.0",
     "diff": "^5.1.0",
     "eslint": "^8.20.0",
-    "eslint-config-hypothesis": "^2.5.0",
+    "eslint-config-hypothesis": "^2.6.0",
     "eslint-plugin-mocha": "^10.0.5",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3157,10 +3157,10 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-hypothesis@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-hypothesis/-/eslint-config-hypothesis-2.5.0.tgz#bc9c281b07923666696c5df1c1f96f3cbace266b"
-  integrity sha512-3KiknU/zX117ggOhDetdbnqn+RupdIsp4XXl9kn8NICc/1ObVY3dt802L01A//ajCGHgiYu5/vR2afsuChlnhw==
+eslint-config-hypothesis@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-hypothesis/-/eslint-config-hypothesis-2.6.0.tgz#627a3f0478c6d732ea776d813be6a70ac2f2d9dd"
+  integrity sha512-CMQSym4Oz2RVKwAAD+cftYPoSRzj3CUBfkytf0UG41wBsKh7eHGCAer8AcibYP8G2JelKoB6K6CzOYviCiBi/A==
 
 eslint-plugin-mocha@^10.0.5:
   version "10.0.5"


### PR DESCRIPTION
The newest eslint-config-hypothesis assumes the use of Prettier, so the
override is not needed.