### PR TITLE
Add `--tags` argument to `git describe`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
 
         # Show version information in the build logs. This command will also be
         # used by `tools/settings.js` to generate the extension version.
-        git describe
+        git describe --tags
     - name: Build packages
       run: |
         make clean # Remove assets from test step


### PR DESCRIPTION
The git-describe npm package, which is used by tools/settings.js to generate a version number, defaults to enabling this flag. Without it only annotated tags are considered, and none of the recently created tags are annotated. Hence to get the build logs to display a version number that matches what is in the built packages, we need to add this flag.