### PR TITLE
Update git identity in "Update client" workflow

### DIFF
--- a/.github/workflows/update-client.yml
+++ b/.github/workflows/update-client.yml
@@ -15,4 +15,7 @@ jobs:
     - name: Install
       run: yarn install --frozen-lockfile
     - name: Update client
-      run: tools/update-client
+      run: |
+        git config --global user.name "Hypothesis GitHub Actions"
+        git config --global user.email "hypothesis@users.noreply.github.com"
+        tools/update-client

--- a/.github/workflows/update-client.yml
+++ b/.github/workflows/update-client.yml
@@ -2,7 +2,7 @@ name: Update client
 on:
   workflow_dispatch:
 jobs:
-  ci:
+  update-client:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
This fixes two issues with the workflow for updating the Hypothesis client:

1. The job name was wrong
2. We need to set a Git identity in order to create a commit

I think there will be some additional steps to work around a restriction that pushes triggered by GitHub Actions cannot trigger other workflows. See https://stackoverflow.com/questions/57921401. I will look into this tomorrow.