### PR TITLE
Run release job "manually" after client update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/update-client.yml
+++ b/.github/workflows/update-client.yml
@@ -19,3 +19,13 @@ jobs:
         git config --global user.name "Hypothesis GitHub Actions"
         git config --global user.email "hypothesis@users.noreply.github.com"
         tools/update-client
+
+  # Release a new version of the extension with the updated client.
+  #
+  # Pushes to the main branch normally trigger this workflow automatically,
+  # but the push by the update-client job doesn't due to GitHub Actions restrictions.
+  # See https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow.
+  release:
+    needs: update-client
+    uses: ./.github/workflows/release.yml
+    name: Release extension


### PR DESCRIPTION
The update-client workflow pushes a commit and tag to main. This would normally trigger the release workflow in turn. This doesn't happen because events triggered by workflows cannot trigger other workflows (since comments), so trigger this workflow manually after the client is updated.