### PR TITLE
Inherit secrets when calling release workflow from update-client

### DIFF
--- a/.github/workflows/update-client.yml
+++ b/.github/workflows/update-client.yml
@@ -29,3 +29,4 @@ jobs:
     needs: update-client
     uses: ./.github/workflows/release.yml
     name: Release extension
+    secrets: inherit


### PR DESCRIPTION
Without this, uploads to the Chrome web store will fail due to missing secrets.