### PR TITLE
Check out new tag when releasing updated client

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: 'Git commit to release'
+        required: false
+        type: string
   workflow_dispatch:
   push:
     branches:
@@ -24,6 +29,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.ref }}
     - name: Cache the node_modules dir
       uses: actions/cache@v2
       with:

--- a/.github/workflows/update-client.yml
+++ b/.github/workflows/update-client.yml
@@ -4,6 +4,8 @@ on:
 jobs:
   update-client:
     runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.update-client.outputs.ref }}
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -15,10 +17,12 @@ jobs:
     - name: Install
       run: yarn install --frozen-lockfile
     - name: Update client
+      id: update-client
       run: |
         git config --global user.name "Hypothesis GitHub Actions"
         git config --global user.email "hypothesis@users.noreply.github.com"
         tools/update-client
+        echo "::set-output ref=$(git rev-parse HEAD)"
 
   # Release a new version of the extension with the updated client.
   #
@@ -30,3 +34,5 @@ jobs:
     uses: ./.github/workflows/release.yml
     name: Release extension
     secrets: inherit
+    with:
+      ref: ${{ needs.update-client.outputs.ref }}


### PR DESCRIPTION
When running the release workflow after updating the client, make sure that the new tag created by the update-client workflow is checked out, instead of the previous commit that was at the tip of the main branch when the update-client workflow was initiated.