### PR TITLE
Fix set-output syntax

### DIFF
--- a/.github/workflows/update-client.yml
+++ b/.github/workflows/update-client.yml
@@ -22,7 +22,7 @@ jobs:
         git config --global user.name "Hypothesis GitHub Actions"
         git config --global user.email "hypothesis@users.noreply.github.com"
         tools/update-client
-        echo "::set-output ref=$(git rev-parse HEAD)"
+        echo "::set-output name=ref::$(git rev-parse HEAD)"
 
   # Release a new version of the extension with the updated client.
   #


### PR DESCRIPTION
Fix the syntax of the set-output command to match the examples in the docs. See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter.