### PR TITLE
Pass ref from release workflow to CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,12 +2,19 @@ name: Continuous integration
 on:
   pull_request:
   workflow_call:
+    inputs:
+      ref:
+        description: 'Git commit to build and test'
+        required: false
+        type: string
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.ref }}
     - name: Cache the node_modules dir
       uses: actions/cache@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
   continuous-integration:
     uses: ./.github/workflows/continuous-integration.yml
     name: continuous integration
+    with:
+      ref: ${{ inputs.ref }}
 
   upload-packages:
     needs: continuous-integration


### PR DESCRIPTION
When the update-client workflow runs the release workflow, it passes the new ref created after the Hypothesis client package is updated. The release workflow was using this ref when running the release scripts, but not when calling the continuous-integration workflow to actually build the client. Hence the built client ended up with the wrong version number. Fix this so that the new ref is passed from update-client to release and then to the continuous-integration workflow.