### PR TITLE
Support building extension for Manifest V3

### DIFF
--- a/src/background/chrome-api.js
+++ b/src/background/chrome-api.js
@@ -74,7 +74,7 @@ export function getChromeAPI(chrome = globalThis.chrome) {
    * @return {(...args: Args) => Promise<Result>}
    */
   const promisifyAlt = fn => {
-    // @ts-ignore
+    // @ts-expect-error
     return promisify(fn);
   };
 
@@ -85,10 +85,7 @@ export function getChromeAPI(chrome = globalThis.chrome) {
       onClicked: browserAction.onClicked,
       setBadgeBackgroundColor: promisify(browserAction.setBadgeBackgroundColor),
       setBadgeText: promisify(browserAction.setBadgeText),
-
-      // @ts-ignore - Ignore an incorrect typing error about setIcon's callback
       setIcon: promisify(browserAction.setIcon),
-
       setTitle: promisify(browserAction.setTitle),
     },
 

--- a/src/background/chrome-api.js
+++ b/src/background/chrome-api.js
@@ -242,11 +242,10 @@ export async function executeFunction(
     }
     const results = await chromeAPI_.scripting.executeScript({
       target,
-      // @ts-expect-error - Typechecking error needs debugging.
       func,
       args,
     });
-    return results[0].result;
+    return /** @type {Result} */ (results[0].result);
   }
 
   const code = codeStringForFunctionCall(func, args);

--- a/src/background/settings.js
+++ b/src/background/settings.js
@@ -9,6 +9,7 @@
  * @prop {string} buildType
  * @prop {{ dsn: string, release: string }} [raven]
  * @prop {string} serviceUrl
+ * @prop {boolean} [manifestV3]
  */
 
 // nb. This will error if the build has not been run yet.

--- a/src/background/tab-state.js
+++ b/src/background/tab-state.js
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error
 import isShallowEqual from 'is-equal-shallow';
 
 import { RequestCanceledError } from './errors';

--- a/src/manifest.json.mustache
+++ b/src/manifest.json.mustache
@@ -5,7 +5,13 @@
   {{#browserIsChrome}}
   "version_name": "{{ version }} ({{ versionName }})",
   {{/browserIsChrome}}
+
+  {{#manifestV3}}
+  "manifest_version": 3,
+  {{/manifestV3}}
+  {{^manifestV3}}
   "manifest_version": 2,
+  {{/manifestV3}}
 
   {{#browserIsChrome}}
   "minimum_chrome_version": "88",
@@ -40,8 +46,7 @@
   {{/browserIsChrome}}
 
   "options_ui": {
-    "page": "options/index.html",
-    "chrome_style": true
+    "page": "options/index.html"
   },
 
   {{#browserIsChrome}}
@@ -49,33 +54,65 @@
   {{/browserIsChrome}}
 
   "permissions": [
+    {{#manifestV3}}
+    "scripting",
+    {{/manifestV3}}
+
+    {{^manifestV3}}
     "<all_urls>",
+    {{/manifestV3}}
 
     "storage",
     "tabs"
   ],
+
+  {{#manifestV3}}
+  "host_permissions": ["<all_urls>"],
+  {{/manifestV3}}
 
   "optional_permissions": [
     {{! Used to enumerate frames on certain websites. }}
     "webNavigation"
   ],
 
+  {{^manifestV3}}
   "content_security_policy": "script-src 'self'; object-src 'self'",
+  {{/manifestV3}}
 
+  {{#manifestV3}}
+  "background": {
+    "service_worker": "extension.bundle.js"
+  },
+  {{/manifestV3}}
+
+  {{^manifestV3}}
   "background": {
     {{#browserIsChrome}}
     "persistent": true,
     {{/browserIsChrome}}
     "scripts": [
       "extension.bundle.js"
-    ]
+     ]
   },
+  {{/manifestV3}}
+
+  {{#manifestV3}}
+  "action": {
+    "default_icon": {
+      "19": "images/browser-icon-inactive.png",
+      "38": "images/browser-icon-inactive@2x.png"
+    }
+  },
+  {{/manifestV3}}
+
+  {{^manifestV3}}
   "browser_action": {
     "default_icon": {
       "19": "images/browser-icon-inactive.png",
       "38": "images/browser-icon-inactive@2x.png"
     }
   },
+  {{/manifestV3}}
 
   {{#browserIsChrome}}
   "externally_connectable": {
@@ -83,10 +120,26 @@
   },
   {{/browserIsChrome}}
 
+  {{#manifestV3}}
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "client/*",
+        "help/*",
+        "pdfjs/*",
+        "pdfjs/web/viewer.html"
+      ],
+      "matches": ["<all_urls>"]
+    }
+  ]
+  {{/manifestV3}}
+
+  {{^manifestV3}}
   "web_accessible_resources": [
     "client/*",
     "help/*",
     "pdfjs/*",
     "pdfjs/web/viewer.html"
   ]
+  {{/manifestV3}}
 }


### PR DESCRIPTION
This PR enables the extension to be built as a Manifest V3 extension by setting the `manifestV3` key to `true` in the settings JSON.

Part of https://github.com/hypothesis/browser-extension/issues/622.

**Summary of changes:**

- Add conditionals in `manifest.json` to build extension for Manifest V3
- Use MV3 APIs for executing scripts (files or functions) in the page when building for Manifest V3

**Testing:**

1. Add `"manifestV3": true` to the settings JSON file you use for development, and build the extension
2. Build the extension and load it in Chrome.
3. Go to the extension's info page under chrome://extension and under "Inspect views" you should see that it displays "Service worker" instead of background page

Example of my local Chrome settings JSON:

```json
{
  "buildType": "dev",
  "manifestV3": true,

  "apiUrl": "http://localhost:5000/api/",
  "authDomain": "localhost",
  "bouncerUrl": "http://localhost:8000/",
  "serviceUrl": "http://localhost:5000/",

  "browserIsChrome": true,
  "appType": "chrome-extension",

  "oauthClientId": "b1a421ec-fd9d-11ea-87b6-cb79e356a0c9"
}
```