### PR TITLE
Update GitHub actions dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.ref }}
     - name: Cache the node_modules dir
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: node_modules
         key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.ref }}
     - name: Cache the node_modules dir
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: node_modules
         key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/update-client.yml
+++ b/.github/workflows/update-client.yml
@@ -8,9 +8,9 @@ jobs:
       ref: ${{ steps.update-client.outputs.ref }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Cache the node_modules dir
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: node_modules
         key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/update-client.yml
+++ b/.github/workflows/update-client.yml
@@ -22,7 +22,7 @@ jobs:
         git config --global user.name "Hypothesis GitHub Actions"
         git config --global user.email "hypothesis@users.noreply.github.com"
         tools/update-client
-        echo "::set-output name=ref::$(git rev-parse HEAD)"
+        echo "ref=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
   # Release a new version of the extension with the updated client.
   #


### PR DESCRIPTION
This pull request addresses a couple of warnings printed in our workflows, by updating to the latest instances of some actions and changing how we pass info between jobs via output.