### PR TITLE
Add profile app HTML to extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ extension: build/manifest.json
 extension: build/client/build
 extension: build/client/app.html
 extension: build/client/notebook.html
+extension: build/client/profile.html
 extension: build/unload-client.js
 extension: build/pdfjs-init.js
 extension: $(addprefix build/,$(EXTENSION_SRC))
@@ -69,6 +70,8 @@ build/client/build: node_modules/hypothesis/build/manifest.json
 build/client/app.html: src/sidebar-app.html.mustache build/client build/settings.json
 	tools/template-context-app.js build/settings.json | $(MUSTACHE) - $< >$@
 build/client/notebook.html: build/client/app.html
+	cp $< $@
+build/client/profile.html: build/client/app.html
 	cp $< $@
 build/unload-client.js: src/unload-client.js
 	cp $< $@

--- a/src/background/extension.js
+++ b/src/background/extension.js
@@ -277,9 +277,6 @@ export class Extension {
 
         const config = {
           // Configure client to load assets and sidebar app from extension.
-          // Note: Even though the sidebar app URL is correct here and the page
-          // does load, Chrome devtools may incorrectly report that it failed to
-          // load. See https://bugs.chromium.org/p/chromium/issues/detail?id=667533
           assetRoot: chromeAPI.runtime.getURL('/client/'),
           notebookAppUrl: chromeAPI.runtime.getURL('/client/notebook.html'),
           profileAppUrl: chromeAPI.runtime.getURL('/client/profile.html'),

--- a/src/background/extension.js
+++ b/src/background/extension.js
@@ -281,8 +281,9 @@ export class Extension {
           // does load, Chrome devtools may incorrectly report that it failed to
           // load. See https://bugs.chromium.org/p/chromium/issues/detail?id=667533
           assetRoot: chromeAPI.runtime.getURL('/client/'),
-          sidebarAppUrl: chromeAPI.runtime.getURL('/client/app.html'),
           notebookAppUrl: chromeAPI.runtime.getURL('/client/notebook.html'),
+          profileAppUrl: chromeAPI.runtime.getURL('/client/profile.html'),
+          sidebarAppUrl: chromeAPI.runtime.getURL('/client/app.html'),
         };
 
         // Pass the direct-link query as configuration into the client.

--- a/tests/background/extension-test.js
+++ b/tests/background/extension-test.js
@@ -695,6 +695,7 @@ describe('Extension', function () {
       assert.calledWith(fakeSidebarInjector.injectIntoTab, tab, {
         assetRoot: 'chrome://1234/client/',
         notebookAppUrl: 'chrome://1234/client/notebook.html',
+        profileAppUrl: 'chrome://1234/client/profile.html',
         sidebarAppUrl: 'chrome://1234/client/app.html',
       });
     });


### PR DESCRIPTION
Like the corresponding route in h (https://github.com/hypothesis/h/pull/7817), this is the same as the sidebar HTML.

We probably want to revisit how these URLs are configured soon, so that we don't need separate files and `<link>` elements for each sidebar-like app in the client. This change unblocks deployments of the extension though. Without this the extension fails to start.

I also removed an obsolete notice about a Chrome bug, which has now been resolved.