### PR TITLE
Bump minimum Chrome version to 88

### DIFF
--- a/src/manifest.json.mustache
+++ b/src/manifest.json.mustache
@@ -8,7 +8,7 @@
   "manifest_version": 2,
 
   {{#browserIsChrome}}
-  "minimum_chrome_version": "64",
+  "minimum_chrome_version": "88",
   {{/browserIsChrome}}
 
   {{#key}}


### PR DESCRIPTION
This is a prerequisite for publishing the extension as a Manifest V3 extension.

Chrome 88 was published in Jan 2021, so > 2 years old at this point. There are some MV3 APIs that require a newer version of Chrome than 88, but I haven't found a need for them yet.

Part of #622