### PR TITLE
Sync client config in PDF.js with config for web pages

### DIFF
--- a/src/background/extension.js
+++ b/src/background/extension.js
@@ -275,8 +275,11 @@ export class Extension {
 
         const { directLinkQuery } = state.getState(tabId);
 
+        // Configure client to load assets from extension.
+        //
+        // Note this configuration is duplicated in `pdfjs-init.js`. Any changes
+        // made here must be reflected there as well.
         const config = {
-          // Configure client to load assets and sidebar app from extension.
           assetRoot: chromeAPI.runtime.getURL('/client/'),
           notebookAppUrl: chromeAPI.runtime.getURL('/client/notebook.html'),
           profileAppUrl: chromeAPI.runtime.getURL('/client/profile.html'),

--- a/src/pdfjs-init.js
+++ b/src/pdfjs-init.js
@@ -7,10 +7,14 @@
 
 // Configure Hypothesis client to load assets from the extension instead of
 // the CDN.
+//
+// Note this configuration is duplicated in `src/background/extension.js`. Any
+// changes made here must be reflected there as well.
 const clientConfig = {
   assetRoot: '/client/',
   sidebarAppUrl: '/client/app.html',
   notebookAppUrl: '/client/notebook.html',
+  profileAppUrl: '/client/profile.html',
 };
 
 const configScript = document.createElement('script');


### PR DESCRIPTION
The `profileAppUrl` setting was added to `src/background/extension.js` but not mirrored in `pdfjs-init.js`. This caused the wrong profile app URL to be used when viewing a PDF. It also lead to a cryptic error from the client's `processUrlTemplate` function when testing with a PDF and a local build of the client, due to `processUrlTemplate` not being able to handle `chrome-extension://` URLs properly.

In future it would be ideal if the `pdjs-init.js` script could share its config object definition with `src/background/extension.js`. Currently however it isn't easy to share code between the two files. It would also be nice to eliminate the need to specify an entry point for a multitude of mini-apps (sidebar, notebook, profile) that constitute the client. That's left as an exercise for the future.

**Testing:**

1. Build local extension from this branch
2. Open a PDF and activate the extension
3. Check `profileAppUrl` configuration is present in the `js-hypothesis-config` script tag in the page