### PR TITLE
Add `data-remove-on-unload` on config script so that it gets removed when the extension is deactivated

### DIFF
--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -22,6 +22,8 @@ function setClientConfig(config) {
   script.className = 'js-hypothesis-config';
   script.type = 'application/json';
   script.textContent = JSON.stringify(config);
+  // This ensures the client removes the script when the extension is deactivated
+  script.setAttribute('data-remove-on-unload', '');
   document.head.appendChild(script);
 }
 

--- a/src/pdfjs-init.js
+++ b/src/pdfjs-init.js
@@ -21,6 +21,8 @@ const configScript = document.createElement('script');
 configScript.type = 'application/json';
 configScript.className = 'js-hypothesis-config';
 configScript.textContent = JSON.stringify(clientConfig);
+// This ensures the client removes the script when the extension is deactivated
+configScript.setAttribute('data-remove-on-unload', '');
 document.head.appendChild(configScript);
 
 // See https://github.com/mozilla/pdf.js/wiki/Third-party-viewer-usage


### PR DESCRIPTION
Closes #1180 

By adding `data-remove-on-unload` attribute to the config script, we ensure the client removes that script when unloaded, which happens when the extension is inactive.

In order to test it, build the dev extension on this branch, and see how the `js-hypothesis-config` script tag gets removed when the extension is deactivated.