### PR TITLE
Request `webNavigation` permission directly after clicking browser action

### DIFF
--- a/src/help/index.html
+++ b/src/help/index.html
@@ -69,6 +69,7 @@
         padding: 10px;
         background-color: #eaeaea;
         border-radius: 2px;
+        font-family: monospace;
       }
     </style>
   </head>
@@ -112,7 +113,7 @@
           The problem has been reported to our team. If it continues, please contact
           <a href="mailto:support@hypothes.is">support@hypothes.is</a> and provide these
           technical details:
-          <code><pre class="error-details js-error-message"></pre></code>
+          <code><div class="error-details js-error-message"></div></code>
         </p>
       </section>
     </article>


### PR DESCRIPTION
Work around an issue in Manifest V3 where async calls in-between a user clicking an extension's toolbar action and attempting to request additional permissions results in an error "The function must be called during a user gesture" when calling `chrome.permissions.request` [1]. In our context this happens when activating Hypothesis on a https://bookshelf.vitalsource.com URL.

The workaround is to request any additional permissions that might be required, based on the tab's URL, immediately after clicking the toolbar action. This workaround relies on us being able to determine what permissions may be needed based on the URL alone, which is currently the case.

In an additional commit I also fixed an issue where error messages of > 60 chars would overflow their container on the extension error info screen.

Part of https://github.com/hypothesis/browser-extension/issues/622.

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=1363490
[2] https://github.com/hypothesis/browser-extension/pull/1031#issuecomment-1504955470

**Testing:**

1. Build a Manifest V3 version of the extension following steps in https://github.com/hypothesis/browser-extension/pull/1031
2. Go to https://bookshelf.vitalsource.com and login (there are credentials in the usual place if you don't have an account)
3. Open a book
4. Activate the extension

After granting permissions, you can test the scenario where the permissions are rejected by removing and re-adding the extension. There might be an easier way to reset granted permissions, but I haven't found it yet.

On the branch in https://github.com/hypothesis/browser-extension/pull/1031 you'll get [an error](https://github.com/hypothesis/browser-extension/pull/1031#issuecomment-1504955470) when attempting to activate the client. On this branch you should get a permissions prompt and then, if you accept that, the client should inject.