### PR TITLE
Enable Manifest V3 by default

### DIFF
--- a/settings/chrome-dev.json
+++ b/settings/chrome-dev.json
@@ -1,5 +1,6 @@
 {
   "buildType": "dev",
+  "manifestV3": true,
 
   "apiUrl": "http://localhost:5000/api/",
   "authDomain": "localhost",

--- a/settings/chrome-prod.json
+++ b/settings/chrome-prod.json
@@ -1,5 +1,6 @@
 {
   "buildType": "production",
+  "manifestV3": true,
   "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCq7XsXE/uakq4aKMG5Smz2nc8VSaandriziGorxX08py3mTkab79GpWYu7j/hA3Yf7fkCLQnX8QoZGj7WdaMX6+b+eHxF7vYpOhEW/Bam7TOlb+5AVmL1KReG9PPTLz4dp+xA4WfK2dqFM+XN40FTbm2G/SNk3GRP3gQOxgy3ZKwIDAQAB",
 
 

--- a/settings/chrome-qa.json
+++ b/settings/chrome-qa.json
@@ -1,5 +1,6 @@
 {
   "buildType": "qa",
+  "manifestV3": true,
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqjbEOhG+ZCl2Bl17m2ltNC+3uw0Fqv3Dzuja5vLnH1MLBRQG7L77pXtKCZgVgFJ2K+Kn0L0OqnMDcKEi5pUpNTi39b8twp1imDsoLO+L5XgpKYBtUgfR+T8OO2INjEgz0LDth0l26WmHNS377KZjSTsfPWNnLozXHHkETgug1lt9VzgcvSboiyZuwk23xHmiqnVpZtuqVAv4HdqFofHiNQn2fF7awsQxEYYNfuSk0Jp33XJkkadyrJ/dQ7vVFi0F0O//Oyaw3s4TD58frABxznusmKkjHZorJUrm2OaYbn/7TSUcG5fReQC08fXiMsFGUKxK01HfAwdmVUAmASL+NwIDAQAB",
 
   "apiUrl": "https://qa.hypothes.is/api/",


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/browser-extension/pull/1031, https://github.com/hypothesis/browser-extension/pull/1195.**~~

Switch the dev, QA and prod Chrome extensions to Manifest V3 by default. See [Slack thread](https://hypothes-is.slack.com/archives/C1M8NH76X/p1681394873609259) for rollout discussion.

Part of https://github.com/hypothesis/browser-extension/issues/622.

**Testing:**

1. Remove the QA and prod Hypothesis extensions, if you have them installed. Also remove any existing local Hypothesis extension.
2. Build the QA extension locally using `make build SETTINGS_FILE=settings/chrome-qa.json` and test it
3. Remove the QA extension from Chrome
4. Build the prod extension locally using `make build SETTINGS_FILE=settings/chrome-prod.json` and test it

