### PR TITLE
Inject extension id as an attribute on generated config

### DIFF
--- a/src/background/chrome-api.js
+++ b/src/background/chrome-api.js
@@ -100,6 +100,7 @@ export function getChromeAPI(chrome = globalThis.chrome) {
     },
 
     runtime: {
+      id: chrome.runtime.id,
       getURL: chrome.runtime.getURL,
       onMessageExternal: chrome.runtime.onMessageExternal,
       onInstalled: chrome.runtime.onInstalled,
@@ -248,4 +249,8 @@ export async function executeFunction(
   const code = codeStringForFunctionCall(func, args);
   const result = await chromeAPI_.tabs.executeScript(tabId, { frameId, code });
   return result[0];
+}
+
+export function getExtensionId(chromeAPI_ = chromeAPI) {
+  return chromeAPI_.runtime.id;
 }

--- a/src/background/sidebar-injector.js
+++ b/src/background/sidebar-injector.js
@@ -1,4 +1,9 @@
-import { chromeAPI, executeFunction, executeScript } from './chrome-api';
+import {
+  chromeAPI,
+  executeFunction,
+  executeScript,
+  getExtensionId,
+} from './chrome-api';
 import { detectContentType } from './detect-content-type';
 import {
   AlreadyInjectedError,
@@ -15,13 +20,15 @@ const CONTENT_TYPE_LMS = 'LMS';
 
 /**
  * @param {object} config
+ * @param {string} extensionId
  */
 /* istanbul ignore next - Code coverage breaks `eval`-ing of this function in tests. */
-function setClientConfig(config) {
+function setClientConfig(config, extensionId) {
   const script = document.createElement('script');
   script.className = 'js-hypothesis-config';
   script.type = 'application/json';
   script.textContent = JSON.stringify(config);
+  script.setAttribute('data-extension-id', extensionId);
   // This ensures the client removes the script when the extension is deactivated
   script.setAttribute('data-remove-on-unload', '');
   document.head.appendChild(script);
@@ -506,11 +513,12 @@ export function SidebarInjector() {
    * @param {number} [frameId]
    */
   function injectConfig(tabId, clientConfig, frameId) {
+    const extensionId = getExtensionId();
     return executeFunction({
       tabId,
       frameId,
       func: setClientConfig,
-      args: [clientConfig],
+      args: [clientConfig, extensionId],
     });
   }
 

--- a/tests/background/chrome-api-test.js
+++ b/tests/background/chrome-api-test.js
@@ -2,6 +2,7 @@ import {
   getChromeAPI,
   executeFunction,
   executeScript,
+  getExtensionId,
 } from '../../src/background/chrome-api';
 
 // Helper defined at top level to simplify its stringified representation.
@@ -224,6 +225,21 @@ describe('chrome-api', () => {
         file: 'foo.js',
       });
       assert.deepEqual(result, 'result');
+    });
+  });
+
+  describe('getExtensionId', () => {
+    let fakeChromeAPI;
+    const id = 'hypothesisId';
+
+    beforeEach(() => {
+      fakeChromeAPI = {
+        runtime: { id },
+      };
+    });
+
+    it('gets ID from `chrome.runtime.id`', () => {
+      assert.equal(getExtensionId(fakeChromeAPI), id);
     });
   });
 });

--- a/tests/background/sidebar-injector-test.js
+++ b/tests/background/sidebar-injector-test.js
@@ -157,6 +157,7 @@ describe('SidebarInjector', function () {
         chromeAPI: fakeChromeAPI,
         executeFunction: fakeExecuteFunction,
         executeScript: fakeExecuteScript,
+        getExtensionId: () => 'hypothesisId',
       },
     });
 
@@ -351,6 +352,7 @@ describe('SidebarInjector', function () {
             tabId: 1,
             frameId: vitalSourceFrames.reader.frameId,
             func: { name: 'setClientConfig' },
+            args: [sinon.match.any, 'hypothesisId'],
           })
         );
 


### PR DESCRIPTION
This PR changes the logic to generate the config script so that it adds an attribute with the ID of the extension that generated it.

This way, the client boot script can then check if there's a config generated by an extension, and which extension specifically, and more granularly determine if it was executed by that extension or not.

![image](https://user-images.githubusercontent.com/2719332/232486686-fd2e9e1c-09a7-488d-b50b-ed6c795e89dd.png)

For more info, see https://github.com/hypothesis/client/pull/5392#discussion_r1168488629

### Testing steps

1. Checkout this branch.
2. Build the browser extension: `make build SETTINGS_FILE=settings/<custom>.json`
3. Load built extension into Chrome.
4. Activate the extension, and verify it has the new `data` attribute with the extension ID.