### PR TITLE
Pass same client configuration to PDFs as for other document types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ extension: build/unload-client.js
 extension: build/pdfjs-init.js
 extension: $(addprefix build/,$(EXTENSION_SRC))
 
-build/extension.bundle.js: src/background/*.js rollup.config.mjs build/settings.json
+build/extension.bundle.js: src/background/*.js src/background/*.ts rollup.config.mjs build/settings.json
 	$(ROLLUP) -c rollup.config.mjs
 build/manifest.json: src/manifest.json.mustache build/settings.json
 	$(MUSTACHE) build/settings.json $< > $@

--- a/src/background/chrome-api.ts
+++ b/src/background/chrome-api.ts
@@ -96,6 +96,7 @@ export function getChromeAPI(chrome = globalThis.chrome) {
     runtime: {
       id: chrome.runtime.id,
       getURL: chrome.runtime.getURL,
+      onMessage: chrome.runtime.onMessage,
       onMessageExternal: chrome.runtime.onMessageExternal,
       onInstalled: chrome.runtime.onInstalled,
       onUpdateAvailable: chrome.runtime.onUpdateAvailable,

--- a/src/background/detect-content-type.ts
+++ b/src/background/detect-content-type.ts
@@ -13,7 +13,7 @@ export type ContentTypeInfo = {
  * In future this could also be extended to support extraction of the URLs of
  * content in embedded viewers where that differs from the tab's main URL.
  *
- * @param document - Document to query
+ * @param document_ - Document to query
  */
 /* istanbul ignore next */
 export function detectContentType(

--- a/src/background/sidebar-injector.ts
+++ b/src/background/sidebar-injector.ts
@@ -180,9 +180,11 @@ export class SidebarInjector {
     };
 
     function getPDFViewerURL(url: string) {
-      // Encode the original URL but preserve the fragment, so that a
-      // '#annotations' fragment in the original URL will persist and trigger the
-      // sidebar to focus and scroll to that annotation when the PDF viewer loads.
+      // Encode the original URL but preserve the fragment. Preserving the
+      // fragment was originally done to support `#annotations:` fragments that
+      // bouncer used to use. Bouncer and the extension now use a different
+      // mechanism to pass direct-linked annotation IDs to the client. However
+      // preserving the fragment may be useful for other reasons.
       const parsedURL = new URL(url);
       const hash = parsedURL.hash;
       parsedURL.hash = '';

--- a/src/pdfjs-init.js
+++ b/src/pdfjs-init.js
@@ -5,35 +5,38 @@
 // This script is run once PDF.js has loaded and it configures the viewer
 // and injects the Hypothesis client.
 
-// Configure Hypothesis client to load assets from the extension instead of
-// the CDN.
-//
-// Note this configuration is duplicated in `src/background/extension.js`. Any
-// changes made here must be reflected there as well.
-const clientConfig = {
-  assetRoot: '/client/',
-  sidebarAppUrl: '/client/app.html',
-  notebookAppUrl: '/client/notebook.html',
-  profileAppUrl: '/client/profile.html',
-};
-
-const configScript = document.createElement('script');
-configScript.type = 'application/json';
-configScript.className = 'js-hypothesis-config';
-configScript.textContent = JSON.stringify(clientConfig);
-// This ensures the client removes the script when the extension is deactivated
-configScript.setAttribute('data-remove-on-unload', '');
-document.head.appendChild(configScript);
-
-// See https://github.com/mozilla/pdf.js/wiki/Third-party-viewer-usage
-document.addEventListener('webviewerloaded', () => {
-  // Wait for the PDF viewer to be fully initialized before loading the client.
-  // Note that the PDF may still be loading after initialization.
-
-  // @ts-expect-error - PDFViewerApplication is missing from types.
-  PDFViewerApplication.initializedPromise.then(() => {
-    const embedScript = document.createElement('script');
-    embedScript.src = '/client/build/boot.js';
-    document.body.appendChild(embedScript);
+async function init() {
+  const configPromise = chrome.runtime.sendMessage(chrome.runtime.id, {
+    type: 'getConfigForTab',
   });
-});
+
+  const viewerLoaded = new Promise(resolve => {
+    // See https://github.com/mozilla/pdf.js/wiki/Third-party-viewer-usage
+    document.addEventListener('webviewerloaded', () => {
+      // Wait for the PDF viewer to be fully initialized before loading the client.
+      // Note that the PDF may still be loading after initialization.
+      //
+      // @ts-expect-error - PDFViewerApplication is missing from types.
+      PDFViewerApplication.initializedPromise.then(resolve);
+    });
+  });
+
+  // Concurrently request Hypothesis client config and listen for PDF.js
+  // to finish initializing.
+  const [config] = await Promise.all([configPromise, viewerLoaded]);
+
+  const configScript = document.createElement('script');
+  configScript.type = 'application/json';
+  configScript.className = 'js-hypothesis-config';
+  configScript.textContent = JSON.stringify(config);
+
+  // This ensures the client removes the script when the extension is deactivated
+  configScript.setAttribute('data-remove-on-unload', '');
+  document.head.appendChild(configScript);
+
+  const embedScript = document.createElement('script');
+  embedScript.src = '/client/build/boot.js';
+  document.body.appendChild(embedScript);
+}
+
+init();

--- a/tests/background/sidebar-injector-test.js
+++ b/tests/background/sidebar-injector-test.js
@@ -267,8 +267,11 @@ describe('SidebarInjector', function () {
     describe('when viewing a remote PDF', function () {
       const url = 'http://example.com/foo.pdf';
 
-      it('navigates page to Hypothesis PDF viewer', async () => {
+      beforeEach(() => {
         contentType = 'PDF';
+      });
+
+      it('navigates page to Hypothesis PDF viewer', async () => {
         const spy = fakeChromeAPI.tabs.update.resolves({ tab: 1 });
 
         await injector.injectIntoTab({ id: 1, url: url });
@@ -279,7 +282,6 @@ describe('SidebarInjector', function () {
       });
 
       it('responds to Hypothesis client config request', async () => {
-        contentType = 'PDF';
         const clientConfig = {
           assetRoot: 'chrome-extension://abc/',
           annotations: 'abc123',
@@ -301,17 +303,15 @@ describe('SidebarInjector', function () {
         assert.calledWith(onMessage.removeListener, onMessageCallback);
       });
 
-      it('preserves #annotations fragments in the URL', function () {
-        contentType = 'PDF';
+      it('preserves fragments in the URL', async () => {
         const spy = fakeChromeAPI.tabs.update.resolves({ tab: 1 });
-        const hash = '#annotations:456';
-        return injector
-          .injectIntoTab({ id: 1, url: url + hash })
-          .then(function () {
-            assert.calledWith(spy, 1, {
-              url: PDF_VIEWER_BASE_URL + encodeURIComponent(url) + hash,
-            });
-          });
+        const hash = '#foobar';
+
+        await injector.injectIntoTab({ id: 1, url: url + hash });
+
+        assert.calledWith(spy, 1, {
+          url: PDF_VIEWER_BASE_URL + encodeURIComponent(url) + hash,
+        });
       });
     });
 


### PR DESCRIPTION
Previously the Hypothesis client config passed to
`SidebarInjector.injectIntoTab` was not used when activating the client in a
PDF. Instead the client used static configuration from pdfjs-init.js. This
caused several problems:

 - When modifying the client config in extension.ts, the developer had to
   remember to update it in pdfjs-init.js separately (see
   96c1dca03492c8e44573d4366a449050d898b3cd for an example of this being
   forgotten).

 - There was no nice mechanism available to pass dynamic configuration to the
   client for PDF documents.

 - Passing of direct link query information from the extension to the client
   worked differently in PDFs than HTML documents. This resulted in direct links
   for PDFs breaking after 3df9fc0ba8f4f1c02f2a004a86390d81c458c282.

This commit resolves the issue by using extension messaging APIs to propagate
the client config passed to `SidebarInjector.injectIntoTab` into the PDF.js
init code in pdfjs-init.js.

Part of https://github.com/hypothesis/browser-extension/issues/1177.

**Testing:**

1. Make sure that annotating PDFs using the extension works
2. Test that direct links to annotations on PDFs works (make sure you have the latest version of the `bouncer` service checked out, and have set the `CHROME_EXTENSION_ID` env var when running it)