### PR TITLE
Convert src/background/{chrome-api.js, detect-content-type.js} to TypeScript

### DIFF
--- a/src/background/detect-content-type.ts
+++ b/src/background/detect-content-type.ts
@@ -1,19 +1,24 @@
+/** Details of the detected content type. */
+export type ContentTypeInfo = {
+  type: 'HTML' | 'PDF';
+};
+
 /**
- * Returns the type of content in the current document,
- * currently either 'PDF' or 'HTML'.
+ * Detect the type of content in the current document.
  *
- * This function is injected as a content script into tabs in
- * order to detect the type of content on the page (PDF, HTML) etc.
- * by sniffing for viewer plugins.
+ * This function is injected as a content script into tabs in order to detect
+ * the type of content on the page (PDF, HTML) etc.  by sniffing for viewer
+ * plugins.
  *
- * In future this could also be extended to support extraction of the URLs
- * of content in embedded viewers where that differs from the tab's
- * main URL.
+ * In future this could also be extended to support extraction of the URLs of
+ * content in embedded viewers where that differs from the tab's main URL.
  *
- * @param {Document} document_ - Test seam
+ * @param document - Document to query
  */
 /* istanbul ignore next */
-export function detectContentType(document_ = document) {
+export function detectContentType(
+  document_ = document
+): ContentTypeInfo | null {
   function detectChromePDFViewer() {
     // When viewing a PDF in Chrome, the viewer consists of a top-level
     // document with an <embed> tag, which in turn instantiates an inner HTML


### PR DESCRIPTION
This converts the remaining "useful" modules in src/background to TypeScript. There is one remaining module, `raven.js`, but that is an old Sentry integration ("raven" was the name of the old Sentry JS client library) that is not currently active. The chrome-api.ts module can be simplified significantly once we finalize the Manifest V3 migration by removing all Manifest V2-related code. I don't want to commit to that until the MV3 extension has been released to production and in use for a few weeks though.