### PR TITLE
Modernize code using async/await, object shorthand syntax and arrow functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,9 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "rules": {
+    "prefer-arrow-callback": ["error", { "allowNamedFunctions": true }],
+    "object-shorthand": ["error", "properties"],
+
     // Upgrade TS rules from warning to error.
     "@typescript-eslint/no-unused-vars": "error",
 

--- a/src/background/browser-action.ts
+++ b/src/background/browser-action.ts
@@ -87,7 +87,7 @@ export class BrowserAction {
     const badgeTheme = badgeThemes[settings.buildType];
     if (badgeTheme) {
       chromeAPI.browserAction.setBadgeBackgroundColor({
-        tabId: tabId,
+        tabId,
         color: badgeTheme.color,
       });
       if (!badgeText) {
@@ -95,9 +95,9 @@ export class BrowserAction {
       }
     }
 
-    chromeAPI.browserAction.setBadgeText({ tabId: tabId, text: badgeText });
-    chromeAPI.browserAction.setIcon({ tabId: tabId, path: activeIcon });
-    chromeAPI.browserAction.setTitle({ tabId: tabId, title: title });
+    chromeAPI.browserAction.setBadgeText({ tabId, text: badgeText });
+    chromeAPI.browserAction.setIcon({ tabId, path: activeIcon });
+    chromeAPI.browserAction.setTitle({ tabId, title });
   }
 
   static icons = icons;

--- a/src/background/raven.js
+++ b/src/background/raven.js
@@ -51,7 +51,7 @@ function translateSourceURLs(data) {
   try {
     /** @type {Array<{ filename: string }>} */
     const frames = data.exception.values[0].stacktrace.frames;
-    frames.forEach(function (frame) {
+    frames.forEach(frame => {
       frame.filename = convertLocalURLsToFilenames(frame.filename);
     });
     data.culprit = frames[0].filename;
@@ -96,8 +96,8 @@ export function report(error, when, context) {
     }
   }
 
-  const extra = Object.assign({ when: when }, context);
-  Raven.captureException(error, { extra: extra });
+  const extra = Object.assign({ when }, context);
+  Raven.captureException(error, { extra });
 }
 
 /**
@@ -115,7 +115,7 @@ export function report(error, when, context) {
  * automatically, in which case this code can simply be removed.
  */
 function installUnhandledPromiseErrorHandler() {
-  globalThis.addEventListener('unhandledrejection', function (event) {
+  globalThis.addEventListener('unhandledrejection', event => {
     if (event.reason) {
       report(event.reason, 'Unhandled Promise rejection');
     }

--- a/src/background/tab-state.ts
+++ b/src/background/tab-state.ts
@@ -112,7 +112,7 @@ export class TabState {
   errorTab(tabId: number, error: Error) {
     this.setState(tabId, {
       state: 'errored',
-      error: error,
+      error,
     });
   }
 

--- a/src/help/index.js
+++ b/src/help/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Detect the current OS and show approprite help.
-chrome.runtime.getPlatformInfo(function (info) {
+chrome.runtime.getPlatformInfo(info => {
   const opts = /** @type {NodeListOf<HTMLElement>} */ (
     document.querySelectorAll('[data-extension-path]')
   );

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -18,7 +18,7 @@ function loadOptions() {
     {
       badge: true,
     },
-    function (items) {
+    items => {
       badgeCheckbox().checked = items.badge;
     }
   );

--- a/tests/background/browser-action-test.js
+++ b/tests/background/browser-action-test.js
@@ -1,10 +1,10 @@
 import { BrowserAction, $imports } from '../../src/background/browser-action';
 
-describe('BrowserAction', function () {
+describe('BrowserAction', () => {
   let action;
   let fakeChromeBrowserAction;
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeChromeBrowserAction = {
       annotationCount: 0,
       title: '',
@@ -37,18 +37,18 @@ describe('BrowserAction', function () {
     $imports.$restore();
   });
 
-  describe('active state', function () {
-    it('sets the active browser icon', function () {
+  describe('active state', () => {
+    it('sets the active browser icon', () => {
       action.update(1, { state: 'active' });
       assert.equal(fakeChromeBrowserAction.icon, BrowserAction.icons.active);
     });
 
-    it('sets the title of the browser icon', function () {
+    it('sets the title of the browser icon', () => {
       action.update(1, { state: 'active' });
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis is active');
     });
 
-    it('does not set the title if there is badge text showing', function () {
+    it('does not set the title if there is badge text showing', () => {
       const state = {
         state: 'inactive',
         annotationCount: 9,
@@ -60,26 +60,26 @@ describe('BrowserAction', function () {
     });
   });
 
-  describe('inactive state', function () {
-    it('sets the inactive browser icon and title', function () {
+  describe('inactive state', () => {
+    it('sets the inactive browser icon and title', () => {
       action.update(1, { state: 'inactive' });
       assert.equal(fakeChromeBrowserAction.icon, BrowserAction.icons.inactive);
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis is inactive');
     });
   });
 
-  describe('error state', function () {
-    it('sets the inactive browser icon', function () {
+  describe('error state', () => {
+    it('sets the inactive browser icon', () => {
       action.update(1, { state: 'errored' });
       assert.equal(fakeChromeBrowserAction.icon, BrowserAction.icons.inactive);
     });
 
-    it('sets the title of the browser icon', function () {
+    it('sets the title of the browser icon', () => {
       action.update(1, { state: 'errored' });
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis failed to load');
     });
 
-    it('still sets the title even there is badge text showing', function () {
+    it('still sets the title even there is badge text showing', () => {
       action.update(1, {
         state: 'errored',
         annotationCount: 9,
@@ -87,7 +87,7 @@ describe('BrowserAction', function () {
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis failed to load');
     });
 
-    it('shows a badge', function () {
+    it('shows a badge', () => {
       action.update(1, {
         state: 'errored',
       });
@@ -95,8 +95,8 @@ describe('BrowserAction', function () {
     });
   });
 
-  describe('annotation counts', function () {
-    it('sets the badge text', function () {
+  describe('annotation counts', () => {
+    it('sets the badge text', () => {
       action.update(1, {
         state: 'inactive',
         annotationCount: 23,
@@ -104,7 +104,7 @@ describe('BrowserAction', function () {
       assert.equal(fakeChromeBrowserAction.badgeText, '23');
     });
 
-    it("sets the badge title when there's 1 annotation", function () {
+    it("sets the badge title when there's 1 annotation", () => {
       action.update(1, {
         state: 'inactive',
         annotationCount: 1,
@@ -115,7 +115,7 @@ describe('BrowserAction', function () {
       );
     });
 
-    it("sets the badge title when there's >1 annotation", function () {
+    it("sets the badge title when there's >1 annotation", () => {
       action.update(1, {
         state: 'inactive',
         annotationCount: 23,
@@ -126,7 +126,7 @@ describe('BrowserAction', function () {
       );
     });
 
-    it('does not set the badge text if there are 0 annotations', function () {
+    it('does not set the badge text if there are 0 annotations', () => {
       action.update(1, {
         state: 'inactive',
         annotationCount: 0,
@@ -134,7 +134,7 @@ describe('BrowserAction', function () {
       assert.equal(fakeChromeBrowserAction.badgeText, '');
     });
 
-    it('does not set the badge title if there are 0 annotations', function () {
+    it('does not set the badge title if there are 0 annotations', () => {
       action.update(1, {
         state: 'inactive',
         annotationCount: 0,
@@ -142,7 +142,7 @@ describe('BrowserAction', function () {
       assert.equal(fakeChromeBrowserAction.title, 'Hypothesis is inactive');
     });
 
-    it("truncates numbers greater than 999 to '999+'", function () {
+    it("truncates numbers greater than 999 to '999+'", () => {
       action.update(1, {
         state: 'inactive',
         annotationCount: 1001,
@@ -155,8 +155,8 @@ describe('BrowserAction', function () {
     });
   });
 
-  describe('build type', function () {
-    beforeEach(function () {
+  describe('build type', () => {
+    beforeEach(() => {
       let fakeSettings = {
         buildType: 'qa',
       };
@@ -172,7 +172,7 @@ describe('BrowserAction', function () {
       $imports.$restore();
     });
 
-    it('sets the text to QA when there are no annotations', function () {
+    it('sets the text to QA when there are no annotations', () => {
       action.update(1, {
         state: 'inactive',
         annotationCount: 0,
@@ -180,7 +180,7 @@ describe('BrowserAction', function () {
       assert.equal(fakeChromeBrowserAction.badgeText, 'QA');
     });
 
-    it('shows the annotation count when there are annotations', function () {
+    it('shows the annotation count when there are annotations', () => {
       action.update(1, {
         state: 'inactive',
         annotationCount: 3,
@@ -188,7 +188,7 @@ describe('BrowserAction', function () {
       assert.equal(fakeChromeBrowserAction.badgeText, '3');
     });
 
-    it('sets the background color', function () {
+    it('sets the background color', () => {
       action.update(1, {
         state: 'inactive',
         annotationCount: 0,

--- a/tests/background/detect-content-type-test.js
+++ b/tests/background/detect-content-type-test.js
@@ -1,27 +1,27 @@
 import { detectContentType } from '../../src/background/detect-content-type';
 
-describe('detectContentType', function () {
+describe('detectContentType', () => {
   let el;
-  beforeEach(function () {
+  beforeEach(() => {
     el = document.createElement('div');
     document.body.appendChild(el);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     el.parentElement.removeChild(el);
   });
 
-  it('returns HTML by default', function () {
+  it('returns HTML by default', () => {
     el.innerHTML = '<div></div>';
     assert.deepEqual(detectContentType(), { type: 'HTML' });
   });
 
-  it('returns "PDF" if Google Chrome PDF viewer is present', function () {
+  it('returns "PDF" if Google Chrome PDF viewer is present', () => {
     el.innerHTML = '<embed type="application/pdf"></embed>';
     assert.deepEqual(detectContentType(), { type: 'PDF' });
   });
 
-  it('returns "PDF" if Firefox PDF viewer is present', function () {
+  it('returns "PDF" if Firefox PDF viewer is present', () => {
     const fakeDocument = {
       querySelector: function () {
         return null;

--- a/tests/background/errors-test.js
+++ b/tests/background/errors-test.js
@@ -1,9 +1,9 @@
 import * as errors from '../../src/background/errors';
 
-describe('errors', function () {
+describe('errors', () => {
   let fakeRaven;
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeRaven = {
       report: sinon.stub(),
     };
@@ -13,12 +13,12 @@ describe('errors', function () {
     sinon.stub(console, 'error');
   });
 
-  afterEach(function () {
+  afterEach(() => {
     console.error.restore();
     errors.$imports.$restore();
   });
 
-  describe('#shouldIgnoreInjectionError', function () {
+  describe('#shouldIgnoreInjectionError', () => {
     const ignoredErrors = [
       'The tab was closed',
       'No tab with id 42',
@@ -30,34 +30,34 @@ describe('errors', function () {
 
     const unexpectedErrors = ['SyntaxError: A typo'];
 
-    it('should be true for "expected" errors', function () {
-      ignoredErrors.forEach(function (message) {
-        const error = { message: message };
+    it('should be true for "expected" errors', () => {
+      ignoredErrors.forEach(message => {
+        const error = { message };
         assert.isTrue(errors.shouldIgnoreInjectionError(error));
       });
     });
 
-    it('should be false for unexpected errors', function () {
-      unexpectedErrors.forEach(function (message) {
-        const error = { message: message };
+    it('should be false for unexpected errors', () => {
+      unexpectedErrors.forEach(message => {
+        const error = { message };
         assert.isFalse(errors.shouldIgnoreInjectionError(error));
       });
     });
 
-    it("should be true for the extension's custom error classes", function () {
+    it("should be true for the extension's custom error classes", () => {
       const error = new errors.LocalFileError('some message');
       assert.isTrue(errors.shouldIgnoreInjectionError(error));
     });
   });
 
-  describe('#report', function () {
-    it('reports unknown errors via Raven', function () {
+  describe('#report', () => {
+    it('reports unknown errors via Raven', () => {
       const error = new Error('A most unexpected error');
       errors.report(error, 'injecting the sidebar');
       assert.calledWith(fakeRaven.report, error, 'injecting the sidebar');
     });
 
-    it('does not report known errors via Raven', function () {
+    it('does not report known errors via Raven', () => {
       const error = new errors.LocalFileError('some message');
       errors.report(error, 'injecting the sidebar');
       assert.notCalled(fakeRaven.report);

--- a/tests/background/extension-test.js
+++ b/tests/background/extension-test.js
@@ -31,7 +31,7 @@ function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe('Extension', function () {
+describe('Extension', () => {
   let sandbox = sinon.createSandbox();
   let ext;
   let fakeChromeAPI;
@@ -41,7 +41,7 @@ describe('Extension', function () {
   let fakeBrowserAction;
   let fakeSidebarInjector;
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeChromeAPI = {
       storage: {
         sync: {
@@ -129,13 +129,13 @@ describe('Extension', function () {
     ext = new Extension();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     sandbox.restore();
     $imports.$restore();
   });
 
-  describe('#firstRun', function () {
-    beforeEach(function () {
+  describe('#firstRun', () => {
+    beforeEach(() => {
       fakeChromeAPI.tabs.create = sandbox.stub().resolves({ id: 1 });
     });
 
@@ -300,13 +300,13 @@ describe('Extension', function () {
       });
     });
 
-    describe('when a tab is created', function () {
+    describe('when a tab is created', () => {
       beforeEach(async () => {
         fakeTabState.clearTab = sandbox.spy();
         await ext.init();
       });
 
-      it('clears the new tab state', function () {
+      it('clears the new tab state', () => {
         fakeChromeAPI.tabs.onCreated.listener({
           id: 1,
           url: 'http://example.com/foo.html',
@@ -315,7 +315,7 @@ describe('Extension', function () {
       });
     });
 
-    describe('when a tab is updated', function () {
+    describe('when a tab is updated', () => {
       const tabState = {};
       function createTab(initialState) {
         const tabId = 1;
@@ -352,7 +352,7 @@ describe('Extension', function () {
         await ext.init();
       });
 
-      it('sets the tab state to ready when loading completes', function () {
+      it('sets the tab state to ready when loading completes', () => {
         const tab = createTab({ state: 'active' });
         fakeChromeAPI.tabs.onUpdated.listener(
           tab.id,
@@ -362,7 +362,7 @@ describe('Extension', function () {
         assert.equal(tabState[tab.id].ready, true);
       });
 
-      it('resets the tab state when loading', function () {
+      it('resets the tab state when loading', () => {
         const tab = createTab({
           state: 'active',
           annotationCount: 8,
@@ -379,7 +379,7 @@ describe('Extension', function () {
         assert.equal(tabState[tab.id].extensionSidebarInstalled, false);
       });
 
-      it('ignores consecutive `loading` events for the same URL and tab until the loading is completed', function () {
+      it('ignores consecutive `loading` events for the same URL and tab until the loading is completed', () => {
         const tab = createTab({
           state: 'active',
           annotationCount: 8,
@@ -418,7 +418,7 @@ describe('Extension', function () {
         assert.equal(tabState[tab.id].extensionSidebarInstalled, false);
       });
 
-      it('resets the tab state when loading a different URL (even when previous loading event did not complete)', function () {
+      it('resets the tab state when loading a different URL (even when previous loading event did not complete)', () => {
         const tab = createTab({
           state: 'active',
           annotationCount: 8,
@@ -446,7 +446,7 @@ describe('Extension', function () {
         assert.equal(tabState[tab.id].extensionSidebarInstalled, false);
       });
 
-      it('resets the tab state to active if errored', function () {
+      it('resets the tab state to active if errored', () => {
         const tab = createTab({ state: 'errored' });
         fakeChromeAPI.tabs.onUpdated.listener(
           tab.id,
@@ -461,7 +461,7 @@ describe('Extension', function () {
         '#annotations:query:blah',
         '#annotations:group:123',
       ].forEach(fragment => {
-        it('injects the sidebar if a direct link is present', function () {
+        it('injects the sidebar if a direct link is present', () => {
           const tab = createTab();
           tab.url += fragment;
           fakeChromeAPI.tabs.onUpdated.listener(
@@ -478,7 +478,7 @@ describe('Extension', function () {
         });
       });
 
-      it('injects the sidebar if the page rewrites the URL fragment', function () {
+      it('injects the sidebar if the page rewrites the URL fragment', () => {
         const tab = createTab();
         const origURL = tab.url;
         tab.url += '#annotations:456';
@@ -528,7 +528,7 @@ describe('Extension', function () {
         );
       });
 
-      it('does not update the badge count if the option is disabled', function () {
+      it('does not update the badge count if the option is disabled', () => {
         const tab = createTab();
         fakeChromeAPI.storage.sync.get.resolves({ badge: false });
 
@@ -547,12 +547,12 @@ describe('Extension', function () {
       });
     });
 
-    describe('when a tab is replaced', function () {
+    describe('when a tab is replaced', () => {
       beforeEach(async () => {
         await ext.init();
       });
 
-      it('preserves the active state of the previous tab', function () {
+      it('preserves the active state of the previous tab', () => {
         fakeTabState.getState = sandbox.stub().returns({
           state: 'active',
         });
@@ -564,7 +564,7 @@ describe('Extension', function () {
         });
       });
 
-      it('reactivates errored tabs', function () {
+      it('reactivates errored tabs', () => {
         fakeTabState.getState = sandbox.stub().returns({
           state: 'errored',
         });
@@ -576,19 +576,19 @@ describe('Extension', function () {
       });
     });
 
-    describe('when a tab is removed', function () {
+    describe('when a tab is removed', () => {
       beforeEach(async () => {
         fakeTabState.clearTab = sandbox.spy();
         await ext.init();
       });
 
-      it('clears the tab', function () {
+      it('clears the tab', () => {
         fakeChromeAPI.tabs.onRemoved.listener(1);
         assert.calledWith(fakeTabState.clearTab, 1);
       });
     });
 
-    describe('when the browser icon is clicked', function () {
+    describe('when the browser icon is clicked', () => {
       beforeEach(async () => {
         await ext.init();
       });
@@ -636,7 +636,7 @@ describe('Extension', function () {
         );
       });
 
-      it('deactivates the tab if the tab is active', function () {
+      it('deactivates the tab if the tab is active', () => {
         fakeTabState.isTabActive.returns(true);
         fakeChromeAPI.browserAction.onClicked.listener({
           id: 1,
@@ -648,7 +648,7 @@ describe('Extension', function () {
     });
   });
 
-  describe('when injection fails', function () {
+  describe('when injection fails', () => {
     function triggerInstall() {
       const tab = { id: 1, url: 'file://foo.html', status: 'complete' };
       const tabState = {
@@ -672,21 +672,21 @@ describe('Extension', function () {
       errors.RestrictedProtocolError,
     ];
 
-    injectErrorCases.forEach(function (ErrorType) {
-      describe('with ' + ErrorType.name, function () {
-        it('puts the tab into an errored state', function () {
+    injectErrorCases.forEach(ErrorType => {
+      describe('with ' + ErrorType.name, () => {
+        it('puts the tab into an errored state', () => {
           const injectError = Promise.reject(new ErrorType('msg'));
           fakeSidebarInjector.injectIntoTab.returns(injectError);
 
           triggerInstall();
 
-          return toResult(injectError).then(function () {
+          return toResult(injectError).then(() => {
             assert.called(fakeTabState.errorTab);
             assert.calledWith(fakeTabState.errorTab, 1);
           });
         });
 
-        it('shows the help page for ' + ErrorType.name, function () {
+        it('shows the help page for ' + ErrorType.name, () => {
           const tab = { id: 1, url: 'file://foo.html' };
 
           fakeTabState.getState.returns({
@@ -704,7 +704,7 @@ describe('Extension', function () {
           );
         });
 
-        it('does not log known errors', function () {
+        it('does not log known errors', () => {
           const error = new Error('Some error');
           fakeErrors.shouldIgnoreInjectionError = function () {
             return true;
@@ -714,19 +714,19 @@ describe('Extension', function () {
 
           triggerInstall();
 
-          return toResult(injectError).then(function () {
+          return toResult(injectError).then(() => {
             assert.notCalled(fakeErrors.report);
           });
         });
 
-        it('logs unexpected errors', function () {
+        it('logs unexpected errors', () => {
           const error = new ErrorType('msg');
           const injectError = Promise.reject(error);
           fakeSidebarInjector.injectIntoTab.returns(injectError);
 
           triggerInstall();
 
-          return toResult(injectError).then(function () {
+          return toResult(injectError).then(() => {
             assert.calledWith(
               fakeErrors.report,
               error,
@@ -739,7 +739,7 @@ describe('Extension', function () {
     });
   });
 
-  describe('TabState.onchange', function () {
+  describe('TabState.onchange', () => {
     let onChangeHandler;
     let tab;
 
@@ -760,7 +760,7 @@ describe('Extension', function () {
       );
     }
 
-    beforeEach(function () {
+    beforeEach(() => {
       tab = { id: 1, status: 'complete' };
       fakeChromeAPI.tabs.get = sandbox.stub().resolves(tab);
       onChangeHandler = ext._onTabStateChange;

--- a/tests/background/help-page-test.js
+++ b/tests/background/help-page-test.js
@@ -1,12 +1,12 @@
 import * as errors from '../../src/background/errors';
 import { HelpPage, $imports } from '../../src/background/help-page';
 
-describe('HelpPage', function () {
+describe('HelpPage', () => {
   let fakeChromeTabs;
   let fakeExtensionURL;
   let help;
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeChromeTabs = { create: sinon.stub() };
     fakeExtensionURL = path => `chrome://abcd${path}`;
 
@@ -26,7 +26,7 @@ describe('HelpPage', function () {
     $imports.$restore();
   });
 
-  describe('showHelpForError', function () {
+  describe('showHelpForError', () => {
     [
       {
         getError: () => new errors.LocalFileError('msg'),
@@ -56,7 +56,7 @@ describe('HelpPage', function () {
       });
     });
 
-    it('renders the "other-error" page for unknown errors', function () {
+    it('renders the "other-error" page for unknown errors', () => {
       help.showHelpForError({ id: 1, index: 1 }, new Error('Unexpected Error'));
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {

--- a/tests/background/sidebar-injector-test.js
+++ b/tests/background/sidebar-injector-test.js
@@ -44,7 +44,7 @@ const vitalSourceFrames = {
   },
 };
 
-describe('SidebarInjector', function () {
+describe('SidebarInjector', () => {
   let injector;
   let fakeChromeAPI;
 
@@ -71,7 +71,7 @@ describe('SidebarInjector', function () {
   // Set of optional permissions that the extension currently has
   let permissions;
 
-  beforeEach(function () {
+  beforeEach(() => {
     contentType = 'HTML';
     isAlreadyInjected = false;
     contentFrame = undefined;
@@ -168,7 +168,7 @@ describe('SidebarInjector', function () {
     injector = new SidebarInjector();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     if (contentFrame) {
       contentFrame.parentNode.removeChild(contentFrame);
     }
@@ -223,26 +223,21 @@ describe('SidebarInjector', function () {
     });
   });
 
-  describe('.injectIntoTab', function () {
+  describe('.injectIntoTab', () => {
     const urls = [
       'chrome://version',
       'chrome-devtools://host',
       'chrome-extension://1234/foo.html',
       'chrome-extension://1234/foo.pdf',
     ];
-    urls.forEach(function (url) {
-      it(
-        'bails early when trying to load an unsupported url: ' + url,
-        function () {
-          return toResult(injector.injectIntoTab({ id: 1, url: url })).then(
-            function (result) {
-              assert.ok(result.error);
-              assert.instanceOf(result.error, errors.RestrictedProtocolError);
-              assert.notCalled(fakeExecuteScript);
-            }
-          );
-        }
-      );
+    urls.forEach(url => {
+      it('bails early when trying to load an unsupported url: ' + url, () => {
+        return toResult(injector.injectIntoTab({ id: 1, url })).then(result => {
+          assert.ok(result.error);
+          assert.instanceOf(result.error, errors.RestrictedProtocolError);
+          assert.notCalled(fakeExecuteScript);
+        });
+      });
     });
 
     [{ id: 1 }, { url: 'https://foobar.com' }].forEach(tab => {
@@ -258,13 +253,13 @@ describe('SidebarInjector', function () {
       });
     });
 
-    it('succeeds if the tab is already displaying the embedded PDF viewer', function () {
+    it('succeeds if the tab is already displaying the embedded PDF viewer', () => {
       const url =
         PDF_VIEWER_BASE_URL + encodeURIComponent('http://origin/foo.pdf');
-      return injector.injectIntoTab({ id: 1, url: url });
+      return injector.injectIntoTab({ id: 1, url });
     });
 
-    describe('when viewing a remote PDF', function () {
+    describe('when viewing a remote PDF', () => {
       const url = 'http://example.com/foo.pdf';
 
       beforeEach(() => {
@@ -274,7 +269,7 @@ describe('SidebarInjector', function () {
       it('navigates page to Hypothesis PDF viewer', async () => {
         const spy = fakeChromeAPI.tabs.update.resolves({ tab: 1 });
 
-        await injector.injectIntoTab({ id: 1, url: url });
+        await injector.injectIntoTab({ id: 1, url });
 
         assert.calledWith(spy, 1, {
           url: PDF_VIEWER_BASE_URL + encodeURIComponent(url),
@@ -287,7 +282,7 @@ describe('SidebarInjector', function () {
           annotations: 'abc123',
         };
 
-        await injector.injectIntoTab({ id: 1, url: url }, clientConfig);
+        await injector.injectIntoTab({ id: 1, url }, clientConfig);
 
         const onMessage = fakeChromeAPI.runtime.onMessage;
         assert.calledOnce(onMessage.addListener);
@@ -315,11 +310,11 @@ describe('SidebarInjector', function () {
       });
     });
 
-    describe('when viewing a remote HTML page', function () {
-      it('injects hypothesis into the page', function () {
+    describe('when viewing a remote HTML page', () => {
+      it('injects hypothesis into the page', () => {
         const url = 'http://example.com/foo.html';
 
-        return injector.injectIntoTab({ id: 1, url: url }).then(function () {
+        return injector.injectIntoTab({ id: 1, url }).then(() => {
           assert.calledWith(
             fakeExecuteScript,
             sinon.match({
@@ -330,25 +325,23 @@ describe('SidebarInjector', function () {
         });
       });
 
-      it('reports an error if Hypothesis is already embedded', function () {
+      it('reports an error if Hypothesis is already embedded', () => {
         embedScriptReturnValue = {
           installedURL: 'https://hypothes.is/app.html',
         };
         const url = 'http://example.com';
-        return toResult(injector.injectIntoTab({ id: 1, url: url })).then(
-          function (result) {
-            assert.ok(result.error);
-            assert.instanceOf(result.error, errors.AlreadyInjectedError);
-          }
-        );
+        return toResult(injector.injectIntoTab({ id: 1, url })).then(result => {
+          assert.ok(result.error);
+          assert.instanceOf(result.error, errors.AlreadyInjectedError);
+        });
       });
 
-      it('injects config options into the page', function () {
+      it('injects config options into the page', () => {
         contentFrame = createTestFrame();
         const url = 'http://example.com';
         return injector
-          .injectIntoTab({ id: 1, url: url }, { annotations: '456' })
-          .then(function () {
+          .injectIntoTab({ id: 1, url }, { annotations: '456' })
+          .then(() => {
             const configEl = contentFrame.contentDocument.querySelector(
               'script.js-hypothesis-config'
             );
@@ -455,14 +448,14 @@ describe('SidebarInjector', function () {
       });
     });
 
-    describe('when viewing a local PDF', function () {
-      describe('when file access is enabled', function () {
-        it('loads the PDFjs viewer', function () {
+    describe('when viewing a local PDF', () => {
+      describe('when file access is enabled', () => {
+        it('loads the PDFjs viewer', () => {
           const spy = fakeChromeAPI.tabs.update.resolves([]);
           const url = 'file:///foo.pdf';
           contentType = 'PDF';
 
-          return injector.injectIntoTab({ id: 1, url: url }).then(function () {
+          return injector.injectIntoTab({ id: 1, url }).then(() => {
             assert.called(spy);
             assert.calledWith(spy, 1, {
               url: PDF_VIEWER_BASE_URL + encodeURIComponent('file:///foo.pdf'),
@@ -471,28 +464,28 @@ describe('SidebarInjector', function () {
         });
       });
 
-      describe('when file access is disabled', function () {
-        beforeEach(function () {
+      describe('when file access is disabled', () => {
+        beforeEach(() => {
           fakeChromeAPI.extension.isAllowedFileSchemeAccess.resolves(false);
           contentType = 'PDF';
         });
 
-        it('returns an error', function () {
+        it('returns an error', () => {
           const url = 'file://foo.pdf';
 
-          const promise = injector.injectIntoTab({ id: 1, url: url });
-          return toResult(promise).then(function (result) {
+          const promise = injector.injectIntoTab({ id: 1, url });
+          return toResult(promise).then(result => {
             assert.instanceOf(result.error, errors.NoFileAccessError);
             assert.notCalled(fakeExecuteScript);
           });
         });
       });
 
-      describe('when viewing a local HTML file', function () {
-        it('returns an error', function () {
+      describe('when viewing a local HTML file', () => {
+        it('returns an error', () => {
           const url = 'file://foo.html';
-          const promise = injector.injectIntoTab({ id: 1, url: url });
-          return toResult(promise).then(function (result) {
+          const promise = injector.injectIntoTab({ id: 1, url });
+          return toResult(promise).then(result => {
             assert.instanceOf(result.error, errors.LocalFileError);
           });
         });
@@ -500,50 +493,50 @@ describe('SidebarInjector', function () {
     });
   });
 
-  describe('#removeFromTab', function () {
-    it('bails early when trying to unload a chrome url', function () {
+  describe('#removeFromTab', () => {
+    it('bails early when trying to unload a chrome url', () => {
       const url = 'chrome://extensions/';
 
-      return injector.removeFromTab({ id: 1, url: url }).then(function () {
+      return injector.removeFromTab({ id: 1, url }).then(() => {
         assert.notCalled(fakeExecuteScript);
       });
     });
 
     const protocols = ['chrome:', 'chrome-devtools:', 'chrome-extension:'];
-    protocols.forEach(function (protocol) {
+    protocols.forEach(protocol => {
       it(
         'bails early when trying to unload an unsupported ' + protocol + ' url',
-        function () {
+        () => {
           const url = protocol + '//foobar/';
 
-          return injector.removeFromTab({ id: 1, url: url }).then(function () {
+          return injector.removeFromTab({ id: 1, url }).then(() => {
             assert.notCalled(fakeExecuteScript);
           });
         }
       );
     });
 
-    describe('when viewing a PDF', function () {
-      it('reverts the tab back to the original document', function () {
+    describe('when viewing a PDF', () => {
+      it('reverts the tab back to the original document', () => {
         const spy = fakeChromeAPI.tabs.update.resolves([]);
         const url =
           PDF_VIEWER_BASE_URL +
           encodeURIComponent('http://example.com/foo.pdf') +
           '#foo';
-        return injector.removeFromTab({ id: 1, url: url }).then(function () {
+        return injector.removeFromTab({ id: 1, url }).then(() => {
           assert.calledWith(spy, 1, {
             url: 'http://example.com/foo.pdf#foo',
           });
         });
       });
 
-      it('drops #annotations fragments', function () {
+      it('drops #annotations fragments', () => {
         const spy = fakeChromeAPI.tabs.update.resolves([]);
         const url =
           PDF_VIEWER_BASE_URL +
           encodeURIComponent('http://example.com/foo.pdf') +
           '#annotations:456';
-        return injector.removeFromTab({ id: 1, url: url }).then(function () {
+        return injector.removeFromTab({ id: 1, url }).then(() => {
           assert.calledWith(spy, 1, {
             url: 'http://example.com/foo.pdf',
           });
@@ -551,12 +544,12 @@ describe('SidebarInjector', function () {
       });
     });
 
-    describe('when viewing an HTML page', function () {
-      it('injects a destroy script into the page', function () {
+    describe('when viewing an HTML page', () => {
+      it('injects a destroy script into the page', () => {
         isAlreadyInjected = true;
         return injector
           .removeFromTab({ id: 1, url: 'http://example.com/foo.html' })
-          .then(function () {
+          .then(() => {
             assert.calledWith(fakeExecuteScript, {
               tabId: 1,
               file: sinon.match('/unload-client.js'),

--- a/tests/promise-util.js
+++ b/tests/promise-util.js
@@ -7,10 +7,10 @@
  */
 export function toResult(promise) {
   return promise
-    .then(function (result) {
-      return { result: result };
+    .then(result => {
+      return { result };
     })
-    .catch(function (err) {
+    .catch(err => {
       return { error: err };
     });
 }

--- a/tests/util.js
+++ b/tests/util.js
@@ -28,18 +28,18 @@
  * @param {Array<T>} fixtures - Array of fixture objects.
  */
 export function unroll(description, testFn, fixtures) {
-  fixtures.forEach(function (fixture) {
-    const caseDescription = Object.keys(fixture).reduce(function (desc, key) {
+  fixtures.forEach(fixture => {
+    const caseDescription = Object.keys(fixture).reduce((desc, key) => {
       return desc.replace('#' + key, String(fixture[key]));
     }, description);
-    it(caseDescription, function (done) {
+    it(caseDescription, done => {
       if (testFn.length === 1) {
         // Test case does not accept a 'done' callback argument, so we either
         // call done() immediately if it returns a non-Promiselike object
         // or when the Promise resolves otherwise
         const result = testFn(fixture);
         if (typeof result === 'object' && result.then) {
-          result.then(function () {
+          result.then(() => {
             done();
           }, done);
         } else {


### PR DESCRIPTION
This PR contains two general code style modernization updates.

- The first commit refactors the function that loads/unloads the client into tabs to use async / await, and also gives it a more obvious name
- The second commit enables the ESLint functions to prefer arrow functions over un-named `function`s (named functions are still allowed) and prefer object shorthand syntax over `foo: foo`. These lint rules are already enabled in client code.