### PR TITLE
Refactor `SidebarInjector` to a more conventional class and rename to `ClientInjector`

### DIFF
--- a/src/background/client-injector.ts
+++ b/src/background/client-injector.ts
@@ -124,11 +124,14 @@ async function canInjectScript(url: string) {
 }
 
 /**
- * The SidebarInjector is used to deploy and remove the Hypothesis sidebar
- * from tabs. It also deals with loading PDF documents into the PDF.js viewer
- * when applicable.
+ * ClientInjector handles loading and unloading the Hypothesis client into tabs.
+ *
+ * For content types which use a viewer application built into the extension
+ * (eg. PDFs) it also handles navigating the tab to the custom viewer when
+ * Hypothesis is activated and back to the original URL when the client is
+ * unloaded.
  */
-export class SidebarInjector {
+export class ClientInjector {
   private _pdfViewerBaseURL: string;
 
   constructor() {
@@ -175,14 +178,14 @@ export class SidebarInjector {
   }
 
   /**
-   * Injects the Hypothesis sidebar into the tab provided.
+   * Injects the Hypothesis client into the tab provided.
    *
    * Certain URLs (eg. VitalSource books) may require extra permissions to
    * inject. These must be obtained by calling {@link requestExtraPermissionsForTab},
    * directly after the user clicks the extension's toolbar icon, before calling
    * this method.
    *
-   * @param tab - A tab object representing the tab to insert the sidebar into.
+   * @param tab - A tab object representing the tab to insert the client into.
    * @param config - An object containing configuration info that is passed to
    *   the app when it loads.
    *
@@ -202,7 +205,7 @@ export class SidebarInjector {
   }
 
   /**
-   * Removes the Hypothesis sidebar from the tab provided.
+   * Removes the Hypothesis client from the tab provided.
    *
    * Returns a promise that will be resolved if the removal succeeded
    * otherwise it will be rejected with an error.

--- a/src/background/errors.ts
+++ b/src/background/errors.ts
@@ -35,7 +35,7 @@ const IGNORED_ERRORS = [
 ];
 
 /**
- * Returns true if a given `err` is anticipated during sidebar injection, such
+ * Returns true if a given `err` is anticipated during client injection, such
  * as the tab being closed by the user, and should not be reported to Sentry.
  *
  * @param err - The Error-like object

--- a/src/background/sidebar-injector.ts
+++ b/src/background/sidebar-injector.ts
@@ -64,443 +64,441 @@ function checkTab(tab: chrome.tabs.Tab): Tab {
   return tab as Tab;
 }
 
+function getPDFViewerURL(pdfViewerBaseURL: string, url: string) {
+  // Encode the original URL but preserve the fragment. Preserving the
+  // fragment was originally done to support `#annotations:` fragments that
+  // bouncer used to use. Bouncer and the extension now use a different
+  // mechanism to pass direct-linked annotation IDs to the client. However
+  // preserving the fragment may be useful for other reasons.
+  const parsedURL = new URL(url);
+  const hash = parsedURL.hash;
+  parsedURL.hash = '';
+  const encodedURL = encodeURIComponent(parsedURL.href);
+  return `${pdfViewerBaseURL}?file=${encodedURL}${hash}`;
+}
+
+/**
+ * Guess the content type of a page from the URL alone.
+ *
+ * This is a fallback for when it is not possible to inject
+ * a content script to determine the type of content in the page.
+ */
+function guessContentTypeFromURL(url: string) {
+  if (url.includes('.pdf')) {
+    return CONTENT_TYPE_PDF;
+  } else {
+    return CONTENT_TYPE_HTML;
+  }
+}
+
+function isVitalSourceURL(url: string) {
+  return url.startsWith('https://bookshelf.vitalsource.com/');
+}
+
+function isLMSAssignmentURL(url: string) {
+  const { origin } = new URL(url);
+  // Matches origins like `lms.hypothes.is`, `qa-lms.hypothes.is`, `lms.ca.hypothes.is`.
+  return /\blms\b/.test(origin) && origin.endsWith('.hypothes.is');
+}
+
+function isSupportedURL(url: string) {
+  // Injection of content scripts is limited to a small number of protocols,
+  // see https://developer.chrome.com/extensions/match_patterns
+  const parsedURL = new URL(url);
+  return ['http:', 'https:', 'ftp:'].includes(parsedURL.protocol);
+}
+
+function isFileURL(url: string) {
+  return url.startsWith('file:');
+}
+
+/**
+ * Returns true if the extension is permitted to inject a content script into
+ * a tab with a given URL.
+ */
+async function canInjectScript(url: string) {
+  if (isFileURL(url)) {
+    return chromeAPI.extension.isAllowedFileSchemeAccess();
+  }
+  return isSupportedURL(url);
+}
+
 /**
  * The SidebarInjector is used to deploy and remove the Hypothesis sidebar
  * from tabs. It also deals with loading PDF documents into the PDF.js viewer
  * when applicable.
  */
 export class SidebarInjector {
-  isClientActiveInTab: (tab: chrome.tabs.Tab) => Promise<boolean>;
-  injectIntoTab: (tab: chrome.tabs.Tab, config: object) => Promise<void>;
-  removeFromTab: (tab: chrome.tabs.Tab) => Promise<void>;
-  requestExtraPermissionsForTab: (tab: chrome.tabs.Tab) => Promise<boolean>;
+  private _pdfViewerBaseURL: string;
 
   constructor() {
-    const pdfViewerBaseURL = chromeAPI.runtime.getURL('/pdfjs/web/viewer.html');
+    this._pdfViewerBaseURL = chromeAPI.runtime.getURL('/pdfjs/web/viewer.html');
+  }
 
-    /**
-     * Check for the presence of the client in a browser tab.
-     *
-     * If code cannot be run in this tab to check the state of the client, it is
-     * assumed to not be active.
-     */
-    this.isClientActiveInTab = async (tab: chrome.tabs.Tab) => {
-      const tab_ = checkTab(tab);
+  /**
+   * Check for the presence of the client in a browser tab.
+   *
+   * If code cannot be run in this tab to check the state of the client, it is
+   * assumed to not be active.
+   */
+  async isClientActiveInTab(tab: chrome.tabs.Tab): Promise<boolean> {
+    const tab_ = checkTab(tab);
 
-      // If this is our PDF viewer, the client is definitely active.
-      if (isPDFViewerURL(tab_.url)) {
-        return true;
-      }
-
-      // In the VitalSource book reader, we need to test a specific frame.
-      let frameId;
-      if (isVitalSourceURL(tab_.url)) {
-        const vsFrame = await getVitalSourceViewerFrame(tab_);
-        if (vsFrame) {
-          frameId = vsFrame.frameId;
-        }
-      }
-
-      try {
-        const extensionURL = chromeAPI.runtime.getURL('/');
-        const isActive = await executeFunction({
-          tabId: tab_.id,
-          frameId,
-          func: isClientActive,
-          args: [extensionURL],
-        });
-        return isActive;
-      } catch {
-        // We failed to run code in this tab, eg. because it is a URL that
-        // disallows extension scripting or it is being unloaded.
-        return false;
-      }
-    };
-
-    /**
-     * Injects the Hypothesis sidebar into the tab provided.
-     *
-     * Certain URLs (eg. VitalSource books) may require extra permissions to
-     * inject. These must be obtained by calling {@link requestExtraPermissionsForTab},
-     * directly after the user clicks the extension's toolbar icon, before calling
-     * this method.
-     *
-     * @param tab - A tab object representing the tab to insert the sidebar into.
-     * @param config - An object containing configuration info that is passed to
-     *   the app when it loads.
-     *
-     * Returns a promise that will be resolved if the injection succeeded
-     * otherwise it will be rejected with an error.
-     */
-    this.injectIntoTab = (tab: chrome.tabs.Tab, config: object = {}) => {
-      const tab_ = checkTab(tab);
-      if (isFileURL(tab_.url)) {
-        return injectIntoLocalDocument(tab_, config);
-      } else {
-        return injectIntoRemoteDocument(tab_, config);
-      }
-    };
-
-    /**
-     * Removes the Hypothesis sidebar from the tab provided.
-     *
-     * Returns a promise that will be resolved if the removal succeeded
-     * otherwise it will be rejected with an error.
-     */
-    this.removeFromTab = (tab: chrome.tabs.Tab) => {
-      const tab_ = checkTab(tab);
-      if (isPDFViewerURL(tab_.url)) {
-        return removeFromPDF(tab_);
-      } else if (isVitalSourceURL(tab_.url)) {
-        return removeFromVitalSource(tab_);
-      } else {
-        return removeFromHTML(tab_);
-      }
-    };
-
-    /**
-     * Request additional permissions that are required to inject Hypothesis
-     * into a given tab.
-     *
-     * Ideally the permissions request would just be part of {@link injectIntoTab}
-     * however it needs to be performed immediately after the user clicks the
-     * extension's toolbar icon, before any async calls, otherwise it will fail
-     * due to lack of a user gesture. See https://bugs.chromium.org/p/chromium/issues/detail?id=1363490.
-     */
-    this.requestExtraPermissionsForTab = async (tab: chrome.tabs.Tab) => {
-      const tab_ = checkTab(tab);
-      if (isVitalSourceURL(tab_.url)) {
-        return await chromeAPI.permissions.request({
-          permissions: ['webNavigation'],
-        });
-      } else {
-        // No extra permissions needed for other tabs.
-        return true;
-      }
-    };
-
-    function getPDFViewerURL(url: string) {
-      // Encode the original URL but preserve the fragment. Preserving the
-      // fragment was originally done to support `#annotations:` fragments that
-      // bouncer used to use. Bouncer and the extension now use a different
-      // mechanism to pass direct-linked annotation IDs to the client. However
-      // preserving the fragment may be useful for other reasons.
-      const parsedURL = new URL(url);
-      const hash = parsedURL.hash;
-      parsedURL.hash = '';
-      const encodedURL = encodeURIComponent(parsedURL.href);
-      return `${pdfViewerBaseURL}?file=${encodedURL}${hash}`;
+    // If this is our PDF viewer, the client is definitely active.
+    if (this.isPDFViewerURL(tab_.url)) {
+      return true;
     }
 
-    /**
-     * Returns true if the extension is permitted to inject a content script into
-     * a tab with a given URL.
-     */
-    async function canInjectScript(url: string) {
-      if (isFileURL(url)) {
-        return chromeAPI.extension.isAllowedFileSchemeAccess();
-      }
-      return isSupportedURL(url);
-    }
-
-    /**
-     * Guess the content type of a page from the URL alone.
-     *
-     * This is a fallback for when it is not possible to inject
-     * a content script to determine the type of content in the page.
-     */
-    function guessContentTypeFromURL(url: string) {
-      if (url.includes('.pdf')) {
-        return CONTENT_TYPE_PDF;
-      } else {
-        return CONTENT_TYPE_HTML;
+    // In the VitalSource book reader, we need to test a specific frame.
+    let frameId;
+    if (isVitalSourceURL(tab_.url)) {
+      const vsFrame = await this.getVitalSourceViewerFrame(tab_);
+      if (vsFrame) {
+        frameId = vsFrame.frameId;
       }
     }
 
-    function isVitalSourceURL(url: string) {
-      return url.startsWith('https://bookshelf.vitalsource.com/');
+    try {
+      const extensionURL = chromeAPI.runtime.getURL('/');
+      const isActive = await executeFunction({
+        tabId: tab_.id,
+        frameId,
+        func: isClientActive,
+        args: [extensionURL],
+      });
+      return isActive;
+    } catch {
+      // We failed to run code in this tab, eg. because it is a URL that
+      // disallows extension scripting or it is being unloaded.
+      return false;
+    }
+  }
+
+  /**
+   * Injects the Hypothesis sidebar into the tab provided.
+   *
+   * Certain URLs (eg. VitalSource books) may require extra permissions to
+   * inject. These must be obtained by calling {@link requestExtraPermissionsForTab},
+   * directly after the user clicks the extension's toolbar icon, before calling
+   * this method.
+   *
+   * @param tab - A tab object representing the tab to insert the sidebar into.
+   * @param config - An object containing configuration info that is passed to
+   *   the app when it loads.
+   *
+   * Returns a promise that will be resolved if the injection succeeded
+   * otherwise it will be rejected with an error.
+   */
+  async injectIntoTab(
+    tab: chrome.tabs.Tab,
+    config: object = {}
+  ): Promise<void> {
+    const tab_ = checkTab(tab);
+    if (isFileURL(tab_.url)) {
+      return this.injectIntoLocalDocument(tab_, config);
+    } else {
+      return this.injectIntoRemoteDocument(tab_, config);
+    }
+  }
+
+  /**
+   * Removes the Hypothesis sidebar from the tab provided.
+   *
+   * Returns a promise that will be resolved if the removal succeeded
+   * otherwise it will be rejected with an error.
+   */
+  removeFromTab(tab: chrome.tabs.Tab): Promise<void> {
+    const tab_ = checkTab(tab);
+    if (this.isPDFViewerURL(tab_.url)) {
+      return this.removeFromPDF(tab_);
+    } else if (isVitalSourceURL(tab_.url)) {
+      return this.removeFromVitalSource(tab_);
+    } else {
+      return this.removeFromHTML(tab_);
+    }
+  }
+
+  /**
+   * Request additional permissions that are required to inject Hypothesis
+   * into a given tab.
+   *
+   * Ideally the permissions request would just be part of {@link injectIntoTab}
+   * however it needs to be performed immediately after the user clicks the
+   * extension's toolbar icon, before any async calls, otherwise it will fail
+   * due to lack of a user gesture. See https://bugs.chromium.org/p/chromium/issues/detail?id=1363490.
+   */
+  async requestExtraPermissionsForTab(tab: chrome.tabs.Tab) {
+    const tab_ = checkTab(tab);
+    if (isVitalSourceURL(tab_.url)) {
+      return await chromeAPI.permissions.request({
+        permissions: ['webNavigation'],
+      });
+    } else {
+      // No extra permissions needed for other tabs.
+      return true;
+    }
+  }
+
+  /**
+   * Returns true if a tab is displaying a PDF using the PDF.js-based
+   * viewer bundled with the extension.
+   */
+  private isPDFViewerURL(url: string) {
+    return url.startsWith(this._pdfViewerBaseURL);
+  }
+
+  private async detectTabContentType(tab: Tab) {
+    if (this.isPDFViewerURL(tab.url)) {
+      return CONTENT_TYPE_PDF;
     }
 
-    function isLMSAssignmentURL(url: string) {
-      const { origin } = new URL(url);
-      // Matches origins like `lms.hypothes.is`, `qa-lms.hypothes.is`, `lms.ca.hypothes.is`.
-      return /\blms\b/.test(origin) && origin.endsWith('.hypothes.is');
+    if (isVitalSourceURL(tab.url)) {
+      return CONTENT_TYPE_VITALSOURCE;
     }
 
-    async function detectTabContentType(tab: Tab) {
-      if (isPDFViewerURL(tab.url)) {
-        return CONTENT_TYPE_PDF;
-      }
+    if (isLMSAssignmentURL(tab.url)) {
+      return CONTENT_TYPE_LMS;
+    }
 
-      if (isVitalSourceURL(tab.url)) {
-        return CONTENT_TYPE_VITALSOURCE;
-      }
-
-      if (isLMSAssignmentURL(tab.url)) {
-        return CONTENT_TYPE_LMS;
-      }
-
-      const canInject = await canInjectScript(tab.url);
-      if (canInject) {
-        const result = await executeFunction({
-          tabId: tab.id,
-          func: detectContentType,
-          args: [],
-        });
-        if (result) {
-          return result.type;
-        } else {
-          // If the content script threw an exception,
-          // frameResults may be null or undefined.
-          //
-          // In that case, fall back to guessing based on the
-          // tab URL
-          return guessContentTypeFromURL(tab.url);
-        }
+    const canInject = await canInjectScript(tab.url);
+    if (canInject) {
+      const result = await executeFunction({
+        tabId: tab.id,
+        func: detectContentType,
+        args: [],
+      });
+      if (result) {
+        return result.type;
       } else {
-        // We cannot inject a content script in order to determine the
-        // file type, so fall back to a URL-based mechanism
+        // If the content script threw an exception,
+        // frameResults may be null or undefined.
+        //
+        // In that case, fall back to guessing based on the
+        // tab URL
         return guessContentTypeFromURL(tab.url);
       }
+    } else {
+      // We cannot inject a content script in order to determine the
+      // file type, so fall back to a URL-based mechanism
+      return guessContentTypeFromURL(tab.url);
+    }
+  }
+
+  private async injectIntoLocalDocument(tab: Tab, clientConfig: object) {
+    const type = await this.detectTabContentType(tab);
+    if (type === CONTENT_TYPE_PDF) {
+      return this.injectIntoLocalPDF(tab, clientConfig);
+    } else {
+      throw new LocalFileError('Local non-PDF files are not supported');
+    }
+  }
+
+  private async injectIntoRemoteDocument(tab: Tab, clientConfig: object) {
+    if (this.isPDFViewerURL(tab.url)) {
+      return;
     }
 
-    /**
-     * Returns true if a tab is displaying a PDF using the PDF.js-based
-     * viewer bundled with the extension.
-     */
-    function isPDFViewerURL(url: string) {
-      return url.startsWith(pdfViewerBaseURL);
+    if (!isSupportedURL(tab.url)) {
+      // Chrome does not permit extensions to inject content scripts
+      // into (chrome*):// URLs and other custom schemes.
+      //
+      // A common case where this happens is when the user has an
+      // extension installed that provides a custom viewer for PDFs
+      // (or some other format). In some cases we could extract the original
+      // URL and open that in the Hypothesis viewer instead.
+      const protocol = tab.url.split(':')[0];
+      throw new RestrictedProtocolError(
+        `Cannot load Hypothesis into ${protocol} pages`
+      );
     }
 
-    function isFileURL(url: string) {
-      return url.startsWith('file:');
-    }
+    const type = await this.detectTabContentType(tab);
 
-    function isSupportedURL(url: string) {
-      // Injection of content scripts is limited to a small number of protocols,
-      // see https://developer.chrome.com/extensions/match_patterns
-      const parsedURL = new URL(url);
-      return ['http:', 'https:', 'ftp:'].includes(parsedURL.protocol);
-    }
-
-    async function injectIntoLocalDocument(tab: Tab, config: object) {
-      const type = await detectTabContentType(tab);
-      if (type === CONTENT_TYPE_PDF) {
-        return injectIntoLocalPDF(tab, config);
-      } else {
-        throw new LocalFileError('Local non-PDF files are not supported');
-      }
-    }
-
-    async function injectIntoRemoteDocument(tab: Tab, config: object) {
-      if (isPDFViewerURL(tab.url)) {
-        return;
-      }
-
-      if (!isSupportedURL(tab.url)) {
-        // Chrome does not permit extensions to inject content scripts
-        // into (chrome*):// URLs and other custom schemes.
-        //
-        // A common case where this happens is when the user has an
-        // extension installed that provides a custom viewer for PDFs
-        // (or some other format). In some cases we could extract the original
-        // URL and open that in the Hypothesis viewer instead.
-        const protocol = tab.url.split(':')[0];
-        throw new RestrictedProtocolError(
-          `Cannot load Hypothesis into ${protocol} pages`
+    if (type === CONTENT_TYPE_PDF) {
+      await this.injectIntoPDF(tab, clientConfig);
+    } else if (type === CONTENT_TYPE_VITALSOURCE) {
+      await this.injectIntoVitalSourceReader(tab, clientConfig);
+    } else if (type === CONTENT_TYPE_LMS) {
+      // The extension is blocked on LMS assignments to avoid confusion with the
+      // embedded Hypothesis instance. The user can still use the extension on other
+      // pages hosted in the LMS itself.
+      throw new BlockedSiteError(
+        "Hypothesis extension can't be used on Hypothesis LMS assignments"
+      );
+    } else {
+      // FIXME - Nothing actually sets `installedURL`. It used to be part of
+      // the client's boot script. See e0bf3fd2a09414170eb991d7837bf6acd821502b.
+      const result = (await this.injectIntoHTML(tab, clientConfig)) as {
+        installedURL: string;
+      } | null;
+      if (
+        typeof result?.installedURL === 'string' &&
+        !result.installedURL.includes(chromeAPI.runtime.getURL('/'))
+      ) {
+        throw new AlreadyInjectedError(
+          'Hypothesis is already injected into this page'
         );
       }
+    }
+  }
 
-      const type = await detectTabContentType(tab);
-
-      if (type === CONTENT_TYPE_PDF) {
-        await injectIntoPDF(tab, config);
-      } else if (type === CONTENT_TYPE_VITALSOURCE) {
-        await injectIntoVitalSourceReader(tab, config);
-      } else if (type === CONTENT_TYPE_LMS) {
-        // The extension is blocked on LMS assignments to avoid confusion with the
-        // embedded Hypothesis instance. The user can still use the extension on other
-        // pages hosted in the LMS itself.
-        throw new BlockedSiteError(
-          "Hypothesis extension can't be used on Hypothesis LMS assignments"
-        );
-      } else {
-        // FIXME - Nothing actually sets `installedURL`. It used to be part of
-        // the client's boot script. See e0bf3fd2a09414170eb991d7837bf6acd821502b.
-        const result = (await injectIntoHTML(tab, config)) as {
-          installedURL: string;
-        } | null;
-        if (
-          typeof result?.installedURL === 'string' &&
-          !result.installedURL.includes(chromeAPI.runtime.getURL('/'))
-        ) {
-          throw new AlreadyInjectedError(
-            'Hypothesis is already injected into this page'
-          );
-        }
-      }
+  private injectIntoPDF(tab: Tab, clientConfig: object) {
+    if (this.isPDFViewerURL(tab.url)) {
+      return Promise.resolve();
     }
 
-    function injectIntoPDF(tab: Tab, config: object) {
-      if (isPDFViewerURL(tab.url)) {
-        return Promise.resolve();
+    const onMessage = chromeAPI.runtime.onMessage;
+    const listener = (
+      request: any,
+      sender: chrome.runtime.MessageSender,
+      sendResponse: (response?: any) => void
+    ) => {
+      if (sender.tab?.id === tab.id && request?.type === 'getConfigForTab') {
+        sendResponse(clientConfig);
+        onMessage.removeListener(listener);
       }
+    };
+    onMessage.addListener(listener);
+    return chromeAPI.tabs.update(tab.id, {
+      url: getPDFViewerURL(this._pdfViewerBaseURL, tab.url),
+    });
+  }
 
-      const onMessage = chromeAPI.runtime.onMessage;
-      const listener = (
-        request: any,
-        sender: chrome.runtime.MessageSender,
-        sendResponse: (response?: any) => void
-      ) => {
-        if (sender.tab?.id === tab.id && request?.type === 'getConfigForTab') {
-          sendResponse(config);
-          onMessage.removeListener(listener);
-        }
-      };
-      onMessage.addListener(listener);
-      return chromeAPI.tabs.update(tab.id, { url: getPDFViewerURL(tab.url) });
+  private async injectIntoLocalPDF(tab: Tab, clientConfig: object) {
+    const isAllowed = await chromeAPI.extension.isAllowedFileSchemeAccess();
+    if (isAllowed) {
+      await this.injectIntoPDF(tab, clientConfig);
+    } else {
+      throw new NoFileAccessError('Local file scheme access denied');
+    }
+  }
+
+  private async injectIntoHTML(tab: Tab, clientConfig: object) {
+    await this.injectConfig(tab.id, clientConfig);
+    return this.executeClientBootScript(tab.id);
+  }
+
+  private async removeFromPDF(tab: Tab) {
+    const parsedURL = new URL(tab.url);
+    const originalURL = parsedURL.searchParams.get('file');
+    if (!originalURL) {
+      throw new Error(`Failed to extract original URL from ${tab.url}`);
+    }
+    let hash = parsedURL.hash;
+
+    // If the original URL was a direct link, drop the #annotations fragment
+    // as otherwise the Chrome extension will re-activate itself on this tab
+    // when the original URL loads.
+    if (hash.startsWith('#annotations:')) {
+      hash = '';
     }
 
-    async function injectIntoLocalPDF(tab: Tab, config: object) {
-      const isAllowed = await chromeAPI.extension.isAllowedFileSchemeAccess();
-      if (isAllowed) {
-        await injectIntoPDF(tab, config);
-      } else {
-        throw new NoFileAccessError('Local file scheme access denied');
-      }
+    await chromeAPI.tabs.update(tab.id, {
+      url: decodeURIComponent(originalURL) + hash,
+    });
+  }
+
+  private async removeFromHTML(tab: Tab) {
+    if (!isSupportedURL(tab.url)) {
+      return;
+    }
+    await executeScript({
+      tabId: tab.id,
+      file: '/unload-client.js',
+    });
+  }
+
+  /**
+   * Find the frame within the VitalSource Bookshelf reader into which the
+   * Hypothesis client should be loaded.
+   *
+   * The frame hierarchy will look like:
+   *
+   * bookshelf.vitalsource.com (Main frame)
+   * |- jigsaw.vitalsource.com (Ebook reader. This is where we want to inject the client)
+   *     |- jigsaw.vitalsource.com (Content of current chapter)
+   */
+  private async getVitalSourceViewerFrame(
+    tab: Tab
+  ): Promise<chrome.webNavigation.GetAllFrameResultDetails | undefined> {
+    // Using `chrome.webNavigation.getAllFrames` requires asking for the
+    // `webNavigation` permission which results in a scary prompt about reading
+    // browser history, even though we only want to get frames for the current
+    // tab :(
+    //
+    // The request for permissions must happen immediately after clicking
+    // the browser action, to avoid an error about it happening outside a user
+    // gesture [1]. This is done by calling `requestExtraPermissionsForTab`
+    // before `injectIntoTab`.
+    //
+    // [1] https://bugs.chromium.org/p/chromium/issues/detail?id=1363490
+    const canUseWebNavigation = (
+      await chromeAPI.permissions.getAll()
+    ).permissions?.includes('webNavigation');
+    if (!canUseWebNavigation) {
+      throw new Error('The extension was not granted required permissions');
     }
 
-    async function injectIntoHTML(tab: Tab, config: object) {
-      await injectConfig(tab.id, config);
-      return executeClientBootScript(tab.id);
+    const frames = await chromeAPI.webNavigation.getAllFrames({
+      tabId: tab.id,
+    });
+    if (!frames) {
+      throw new Error('Could not list frames in tab');
     }
 
-    async function removeFromPDF(tab: Tab) {
-      const parsedURL = new URL(tab.url);
-      const originalURL = parsedURL.searchParams.get('file');
-      if (!originalURL) {
-        throw new Error(`Failed to extract original URL from ${tab.url}`);
-      }
-      let hash = parsedURL.hash;
-
-      // If the original URL was a direct link, drop the #annotations fragment
-      // as otherwise the Chrome extension will re-activate itself on this tab
-      // when the original URL loads.
-      if (hash.startsWith('#annotations:')) {
-        hash = '';
-      }
-
-      await chromeAPI.tabs.update(tab.id, {
-        url: decodeURIComponent(originalURL) + hash,
-      });
-    }
-
-    async function removeFromHTML(tab: Tab) {
-      if (!isSupportedURL(tab.url)) {
-        return;
-      }
-      await executeScript({
-        tabId: tab.id,
-        file: '/unload-client.js',
-      });
-    }
-
-    /**
-     * Find the frame within the VitalSource Bookshelf reader into which the
-     * Hypothesis client should be loaded.
-     *
-     * The frame hierarchy will look like:
-     *
-     * bookshelf.vitalsource.com (Main frame)
-     * |- jigsaw.vitalsource.com (Ebook reader. This is where we want to inject the client)
-     *     |- jigsaw.vitalsource.com (Content of current chapter)
-     */
-    async function getVitalSourceViewerFrame(
-      tab: Tab
-    ): Promise<chrome.webNavigation.GetAllFrameResultDetails | undefined> {
-      // Using `chrome.webNavigation.getAllFrames` requires asking for the
-      // `webNavigation` permission which results in a scary prompt about reading
-      // browser history, even though we only want to get frames for the current
-      // tab :(
-      //
-      // The request for permissions must happen immediately after clicking
-      // the browser action, to avoid an error about it happening outside a user
-      // gesture [1]. This is done by calling `requestExtraPermissionsForTab`
-      // before `injectIntoTab`.
-      //
-      // [1] https://bugs.chromium.org/p/chromium/issues/detail?id=1363490
-      const canUseWebNavigation = (
-        await chromeAPI.permissions.getAll()
-      ).permissions?.includes('webNavigation');
-      if (!canUseWebNavigation) {
-        throw new Error('The extension was not granted required permissions');
+    return frames.find(frame => {
+      const frameURL = new URL(frame.url);
+      if (
+        frameURL.hostname !== 'jigsaw.vitalsource.com' ||
+        !frameURL.pathname.startsWith('/mosaic/wrapper.html')
+      ) {
+        return null;
       }
 
-      const frames = await chromeAPI.webNavigation.getAllFrames({
-        tabId: tab.id,
-      });
-      if (!frames) {
-        throw new Error('Could not list frames in tab');
-      }
+      return frame;
+    });
+  }
 
-      return frames.find(frame => {
-        const frameURL = new URL(frame.url);
-        if (
-          frameURL.hostname !== 'jigsaw.vitalsource.com' ||
-          !frameURL.pathname.startsWith('/mosaic/wrapper.html')
-        ) {
-          return null;
-        }
-
-        return frame;
-      });
+  private async injectIntoVitalSourceReader(tab: Tab, config: object) {
+    const frame = await this.getVitalSourceViewerFrame(tab);
+    if (!frame) {
+      throw new Error('Book viewer frame not found');
     }
+    await this.injectConfig(tab.id, config, frame.frameId);
+    await this.executeClientBootScript(tab.id, frame.frameId);
+  }
 
-    async function injectIntoVitalSourceReader(tab: Tab, config: object) {
-      const frame = await getVitalSourceViewerFrame(tab);
-      if (!frame) {
-        throw new Error('Book viewer frame not found');
-      }
-      await injectConfig(tab.id, config, frame.frameId);
-      await executeClientBootScript(tab.id, frame.frameId);
+  private async removeFromVitalSource(tab: Tab) {
+    const frame = await this.getVitalSourceViewerFrame(tab);
+    if (!frame) {
+      return;
     }
+    await executeScript({
+      tabId: tab.id,
+      frameId: frame.frameId,
+      file: '/unload-client.js',
+    });
+  }
 
-    async function removeFromVitalSource(tab: Tab) {
-      const frame = await getVitalSourceViewerFrame(tab);
-      if (!frame) {
-        return;
-      }
-      await executeScript({
-        tabId: tab.id,
-        frameId: frame.frameId,
-        file: '/unload-client.js',
-      });
-    }
+  /**
+   * Inject configuration for the Hypothesis client into the page via a
+   * JSON <script> tag.
+   */
+  private injectConfig(tabId: number, clientConfig: object, frameId?: number) {
+    const extensionId = getExtensionId();
+    return executeFunction({
+      tabId,
+      frameId,
+      func: setClientConfig,
+      args: [clientConfig, extensionId],
+    });
+  }
 
-    /**
-     * Inject configuration for the Hypothesis client into the page via a
-     * JSON <script> tag.
-     */
-    function injectConfig(
-      tabId: number,
-      clientConfig: object,
-      frameId?: number
-    ) {
-      const extensionId = getExtensionId();
-      return executeFunction({
-        tabId,
-        frameId,
-        func: setClientConfig,
-        args: [clientConfig, extensionId],
-      });
-    }
-
-    async function executeClientBootScript(tabId: number, frameId?: number) {
-      return executeScript({
-        tabId,
-        frameId,
-        file: '/client/build/boot.js',
-      });
-    }
+  private async executeClientBootScript(tabId: number, frameId?: number) {
+    return executeScript({
+      tabId,
+      frameId,
+      file: '/client/build/boot.js',
+    });
   }
 }

--- a/tests/background/client-injector-test.js
+++ b/tests/background/client-injector-test.js
@@ -1,8 +1,5 @@
 import * as errors from '../../src/background/errors';
-import {
-  SidebarInjector,
-  $imports,
-} from '../../src/background/sidebar-injector';
+import { ClientInjector, $imports } from '../../src/background/client-injector';
 import { toResult } from '../promise-util';
 
 // The root URL for the extension returned by the
@@ -13,7 +10,7 @@ const PDF_VIEWER_BASE_URL = EXTENSION_BASE_URL + '/pdfjs/web/viewer.html?file=';
 
 /**
  * Creates an <iframe> for testing the effects of code injected
- * into the page by the sidebar injector
+ * into the page by the client injector
  */
 function createTestFrame() {
   const frame = document.createElement('iframe');
@@ -44,7 +41,7 @@ const vitalSourceFrames = {
   },
 };
 
-describe('SidebarInjector', () => {
+describe('ClientInjector', () => {
   let injector;
   let fakeChromeAPI;
 
@@ -55,11 +52,11 @@ describe('SidebarInjector', () => {
   // the page should report ('HTML' or 'PDF')
   let contentType;
   // The return value from the content script which checks whether
-  // the sidebar has already been injected into the page
+  // the client has already been injected into the page
   let isAlreadyInjected;
 
   // An <iframe> created by some tests to verify the effects on the DOM of
-  // code injected into the page by the sidebar
+  // code injected into the page by the client
   let contentFrame;
 
   // Mock return value from embed.js when injected into page
@@ -165,7 +162,7 @@ describe('SidebarInjector', () => {
       },
     });
 
-    injector = new SidebarInjector();
+    injector = new ClientInjector();
   });
 
   afterEach(() => {

--- a/tests/background/errors-test.js
+++ b/tests/background/errors-test.js
@@ -44,8 +44,8 @@ describe('errors', () => {
   describe('#report', () => {
     it('logs errors', () => {
       const error = new Error('A most unexpected error');
-      errors.report(error, 'injecting the sidebar', { foo: 'bar' });
-      assert.calledWith(console.error, 'injecting the sidebar', error, {
+      errors.report(error, 'injecting the client', { foo: 'bar' });
+      assert.calledWith(console.error, 'injecting the client', error, {
         foo: 'bar',
       });
     });


### PR DESCRIPTION
This class handles loading and unloading the whole Hypothesis client into a tab. The sidebar is just one component of the client, so `ClientInjector` is a more appropriate/accurate name. The class documentation has also been updated accordingly.

Internally this class had all of its logic in the constructor, including method definitions via property assignments. This comes from its pre-ES6 heritage. Refactor it to a more conventional class, which should be easier to navigate around than one very large function. It also allows tooling to understand it better.

The tests are unchanged except for replacing references to "sidebar" with "client".