### PR TITLE
Enable grouped updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,21 @@ updates:
     interval: weekly
     time: "10:00"
   open-pull-requests-limit: 10
+  groups:
+    babel:
+      patterns:
+        - '@babel/*'
+    eslint:
+      patterns:
+        - 'eslint*'
+        - '@typescript-eslint/*'
+    rollup:
+      patterns:
+        - 'rollup'
+        - '@rollup/*'
+    sentry:
+      patterns:
+        - '@sentry/*'
+    typescript-types:
+      patterns:
+        - '@types/*'


### PR DESCRIPTION
See https://github.com/hypothesis/lms/pull/5719. The config was copied from the client repo.