### PR TITLE
Make Manifest V3 the default and only build option

### DIFF
--- a/settings/chrome-dev.json
+++ b/settings/chrome-dev.json
@@ -1,6 +1,5 @@
 {
   "buildType": "dev",
-  "manifestV3": true,
 
   "apiUrl": "http://localhost:5000/api/",
   "authDomain": "localhost",

--- a/settings/chrome-prod.json
+++ b/settings/chrome-prod.json
@@ -1,6 +1,5 @@
 {
   "buildType": "production",
-  "manifestV3": true,
   "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCq7XsXE/uakq4aKMG5Smz2nc8VSaandriziGorxX08py3mTkab79GpWYu7j/hA3Yf7fkCLQnX8QoZGj7WdaMX6+b+eHxF7vYpOhEW/Bam7TOlb+5AVmL1KReG9PPTLz4dp+xA4WfK2dqFM+XN40FTbm2G/SNk3GRP3gQOxgy3ZKwIDAQAB",
 
 

--- a/settings/chrome-qa.json
+++ b/settings/chrome-qa.json
@@ -1,6 +1,5 @@
 {
   "buildType": "qa",
-  "manifestV3": true,
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqjbEOhG+ZCl2Bl17m2ltNC+3uw0Fqv3Dzuja5vLnH1MLBRQG7L77pXtKCZgVgFJ2K+Kn0L0OqnMDcKEi5pUpNTi39b8twp1imDsoLO+L5XgpKYBtUgfR+T8OO2INjEgz0LDth0l26WmHNS377KZjSTsfPWNnLozXHHkETgug1lt9VzgcvSboiyZuwk23xHmiqnVpZtuqVAv4HdqFofHiNQn2fF7awsQxEYYNfuSk0Jp33XJkkadyrJ/dQ7vVFi0F0O//Oyaw3s4TD58frABxznusmKkjHZorJUrm2OaYbn/7TSUcG5fReQC08fXiMsFGUKxK01HfAwdmVUAmASL+NwIDAQAB",
 
   "apiUrl": "https://qa.hypothes.is/api/",

--- a/src/background/settings.ts
+++ b/src/background/settings.ts
@@ -8,7 +8,6 @@ export type Settings = {
   apiUrl: string;
   buildType: string;
   serviceUrl: string;
-  manifestV3?: boolean;
 };
 
 // nb. This will error if the build has not been run yet.

--- a/src/manifest.json.mustache
+++ b/src/manifest.json.mustache
@@ -5,13 +5,7 @@
   {{#browserIsChrome}}
   "version_name": "{{ version }} ({{ versionName }})",
   {{/browserIsChrome}}
-
-  {{#manifestV3}}
   "manifest_version": 3,
-  {{/manifestV3}}
-  {{^manifestV3}}
-  "manifest_version": 2,
-  {{/manifestV3}}
 
   {{#browserIsChrome}}
   "minimum_chrome_version": "88",
@@ -54,65 +48,28 @@
   {{/browserIsChrome}}
 
   "permissions": [
-    {{#manifestV3}}
     "scripting",
-    {{/manifestV3}}
-
-    {{^manifestV3}}
-    "<all_urls>",
-    {{/manifestV3}}
-
     "storage",
     "tabs"
   ],
 
-  {{#manifestV3}}
   "host_permissions": ["<all_urls>"],
-  {{/manifestV3}}
 
   "optional_permissions": [
     {{! Used to enumerate frames on certain websites. }}
     "webNavigation"
   ],
 
-  {{^manifestV3}}
-  "content_security_policy": "script-src 'self'; object-src 'self'",
-  {{/manifestV3}}
-
-  {{#manifestV3}}
   "background": {
     "service_worker": "extension.bundle.js"
   },
-  {{/manifestV3}}
 
-  {{^manifestV3}}
-  "background": {
-    {{#browserIsChrome}}
-    "persistent": true,
-    {{/browserIsChrome}}
-    "scripts": [
-      "extension.bundle.js"
-     ]
-  },
-  {{/manifestV3}}
-
-  {{#manifestV3}}
   "action": {
     "default_icon": {
       "19": "images/browser-icon-inactive.png",
       "38": "images/browser-icon-inactive@2x.png"
     }
   },
-  {{/manifestV3}}
-
-  {{^manifestV3}}
-  "browser_action": {
-    "default_icon": {
-      "19": "images/browser-icon-inactive.png",
-      "38": "images/browser-icon-inactive@2x.png"
-    }
-  },
-  {{/manifestV3}}
 
   {{#browserIsChrome}}
   "externally_connectable": {
@@ -120,7 +77,6 @@
   },
   {{/browserIsChrome}}
 
-  {{#manifestV3}}
   "web_accessible_resources": [
     {
       "resources": [
@@ -132,14 +88,4 @@
       "matches": ["<all_urls>"]
     }
   ]
-  {{/manifestV3}}
-
-  {{^manifestV3}}
-  "web_accessible_resources": [
-    "client/*",
-    "help/*",
-    "pdfjs/*",
-    "pdfjs/web/viewer.html"
-  ]
-  {{/manifestV3}}
 }

--- a/tests/background/chrome-api-test.js
+++ b/tests/background/chrome-api-test.js
@@ -1,14 +1,4 @@
-import {
-  getChromeAPI,
-  executeFunction,
-  executeScript,
-  getExtensionId,
-} from '../../src/background/chrome-api';
-
-// Helper defined at top level to simplify its stringified representation.
-function testFunc(a, b) {
-  return a + b;
-}
+import { getChromeAPI, getExtensionId } from '../../src/background/chrome-api';
 
 describe('chrome-api', () => {
   describe('getChromeAPI', () => {
@@ -49,7 +39,6 @@ describe('chrome-api', () => {
         tabs: {
           create: sinon.stub(),
           get: sinon.stub(),
-          executeScript: sinon.stub(),
           onCreated: fakeListener(),
           onReplaced: fakeListener(),
           onRemoved: fakeListener(),
@@ -137,94 +126,6 @@ describe('chrome-api', () => {
 
         assert.equal(actualFrames, frames);
       });
-    });
-  });
-
-  describe('executeFunction', () => {
-    let fakeChromeAPI;
-
-    beforeEach(() => {
-      fakeChromeAPI = {
-        tabs: {
-          executeScript: sinon.stub().resolves(['result']),
-        },
-      };
-    });
-
-    it('calls `chrome.tabs.executeScript` with stringified source', async () => {
-      const result = await executeFunction(
-        {
-          tabId: 1,
-          func: testFunc,
-          args: [1, 2],
-        },
-        fakeChromeAPI,
-      );
-      assert.calledWith(fakeChromeAPI.tabs.executeScript, 1, {
-        frameId: undefined,
-        code: '(function testFunc(a, b) {\n  return a + b;\n})(1,2)',
-      });
-      assert.equal(result, 'result');
-    });
-
-    it('sets frame ID if provided', async () => {
-      const result = await executeFunction(
-        {
-          tabId: 1,
-          frameId: 2,
-          func: testFunc,
-          args: [1, 2],
-        },
-        fakeChromeAPI,
-      );
-      assert.calledWith(fakeChromeAPI.tabs.executeScript, 1, {
-        frameId: 2,
-        code: '(function testFunc(a, b) {\n  return a + b;\n})(1,2)',
-      });
-      assert.equal(result, 'result');
-    });
-  });
-
-  describe('executeScript', () => {
-    let fakeChromeAPI;
-
-    beforeEach(() => {
-      fakeChromeAPI = {
-        tabs: {
-          executeScript: sinon.stub().resolves(['result']),
-        },
-      };
-    });
-
-    it('calls `chrome.tabs.executeScript` with files', async () => {
-      const result = await executeScript(
-        {
-          tabId: 1,
-          file: 'foo.js',
-        },
-        fakeChromeAPI,
-      );
-      assert.calledWith(fakeChromeAPI.tabs.executeScript, 1, {
-        frameId: undefined,
-        file: 'foo.js',
-      });
-      assert.equal(result, 'result');
-    });
-
-    it('sets frame ID if provided', async () => {
-      const result = await executeScript(
-        {
-          tabId: 1,
-          frameId: 2,
-          file: 'foo.js',
-        },
-        fakeChromeAPI,
-      );
-      assert.calledWith(fakeChromeAPI.tabs.executeScript, 1, {
-        frameId: 2,
-        file: 'foo.js',
-      });
-      assert.deepEqual(result, 'result');
     });
   });
 


### PR DESCRIPTION
Remove support for building the extension using Manifest V2. We've been shipping our extension as Manifest V3 since April 2023 and have not encountered any issues. Removing Manifest V2 support will simplify future development.

Fixes https://github.com/hypothesis/browser-extension/issues/1210