### PR TITLE
Update configuration for QA/staging extension

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,9 +43,9 @@ jobs:
     - name: Build packages
       run: |
         make clean # Remove assets from test step
-        make build SETTINGS_FILE=settings/chrome-qa.json dist/ci-chrome-qa.zip
+        make build SETTINGS_FILE=settings/chrome-staging.json dist/ci-chrome-staging.zip
         make build SETTINGS_FILE=settings/chrome-prod.json dist/ci-chrome-prod.zip
-        make build SETTINGS_FILE=settings/firefox-qa.json dist/ci-firefox-qa.xpi
+        make build SETTINGS_FILE=settings/firefox-staging.json dist/ci-firefox-staging.xpi
         make build SETTINGS_FILE=settings/firefox-prod.json dist/ci-firefox-prod.xpi
     - name: Archive packages
       uses: actions/upload-artifact@v3

--- a/settings/chrome-staging.json
+++ b/settings/chrome-staging.json
@@ -1,13 +1,13 @@
 {
-  "buildType": "qa",
+  "buildType": "staging",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqjbEOhG+ZCl2Bl17m2ltNC+3uw0Fqv3Dzuja5vLnH1MLBRQG7L77pXtKCZgVgFJ2K+Kn0L0OqnMDcKEi5pUpNTi39b8twp1imDsoLO+L5XgpKYBtUgfR+T8OO2INjEgz0LDth0l26WmHNS377KZjSTsfPWNnLozXHHkETgug1lt9VzgcvSboiyZuwk23xHmiqnVpZtuqVAv4HdqFofHiNQn2fF7awsQxEYYNfuSk0Jp33XJkkadyrJ/dQ7vVFi0F0O//Oyaw3s4TD58frABxznusmKkjHZorJUrm2OaYbn/7TSUcG5fReQC08fXiMsFGUKxK01HfAwdmVUAmASL+NwIDAQAB",
 
-  "apiUrl": "https://qa.hypothes.is/api/",
+  "apiUrl": "https://staging.hypothes.is/api/",
   "authDomain": "hypothes.is",
-  "bouncerUrl": "https://qa.hyp.is/",
-  "serviceUrl": "https://qa.hypothes.is/",
+  "bouncerUrl": "https://staging.hyp.is/",
+  "serviceUrl": "https://staging.hypothes.is/",
 
-  "oauthClientId": "da545114-7792-11e7-90b4-b35c52774c7d",
+  "oauthClientId": "ca0ef8b2-bc24-11ee-b317-433c505e7e42",
 
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
 

--- a/settings/firefox-staging.json
+++ b/settings/firefox-staging.json
@@ -1,10 +1,10 @@
 {
-  "buildType": "qa",
+  "buildType": "staging",
 
-  "apiUrl": "https://qa.hypothes.is/api/",
+  "apiUrl": "https://staging.hypothes.is/api/",
   "authDomain": "hypothes.is",
-  "bouncerUrl": "https://qa.hyp.is/",
-  "serviceUrl": "https://qa.hypothes.is/",
+  "bouncerUrl": "https://staging.hyp.is/",
+  "serviceUrl": "https://staging.hypothes.is/",
 
   "oauthClientId": "92b42e3c-7793-11e7-8e17-cb2151436a1f",
 

--- a/src/background/browser-action.ts
+++ b/src/background/browser-action.ts
@@ -25,8 +25,8 @@ const badgeThemes: Record<string, { defaultText: string; color: string }> = {
     defaultText: 'DEV',
     color: '#5BCF59', // Emerald green
   },
-  qa: {
-    defaultText: 'QA',
+  staging: {
+    defaultText: 'STG',
     color: '#EDA061', // Porche orange-pink
   },
 };

--- a/src/background/sidebar-injector.ts
+++ b/src/background/sidebar-injector.ts
@@ -223,7 +223,7 @@ export class SidebarInjector {
 
     function isLMSAssignmentURL(url: string) {
       const { origin } = new URL(url);
-      // Matches origins like `lms.hypothes.is`, `qa-lms.hypothes.is`, `lms.ca.hypothes.is`.
+      // Matches origins like `lms.hypothes.is`, `staging-lms.hypothes.is`, `lms.ca.hypothes.is`.
       return /\blms\b/.test(origin) && origin.endsWith('.hypothes.is');
     }
 

--- a/tests/background/browser-action-test.js
+++ b/tests/background/browser-action-test.js
@@ -158,7 +158,7 @@ describe('BrowserAction', () => {
   describe('build type', () => {
     beforeEach(() => {
       let fakeSettings = {
-        buildType: 'qa',
+        buildType: 'staging',
       };
       $imports.$mock({
         './settings': {
@@ -172,12 +172,12 @@ describe('BrowserAction', () => {
       $imports.$restore();
     });
 
-    it('sets the text to QA when there are no annotations', () => {
+    it('sets the text to STG when there are no annotations', () => {
       action.update(1, {
         state: 'inactive',
         annotationCount: 0,
       });
-      assert.equal(fakeChromeBrowserAction.badgeText, 'QA');
+      assert.equal(fakeChromeBrowserAction.badgeText, 'STG');
     });
 
     it('shows the annotation count when there are annotations', () => {

--- a/tests/background/sidebar-injector-test.js
+++ b/tests/background/sidebar-injector-test.js
@@ -436,7 +436,7 @@ describe('SidebarInjector', () => {
         try {
           await injector.injectIntoTab({
             id: 1,
-            url: 'https://qa-lms.ca.hypothes.is/lti_launches',
+            url: 'https://staging-lms.ca.hypothes.is/lti_launches',
           });
         } catch (err) {
           error = err;

--- a/tools/deploy
+++ b/tools/deploy
@@ -6,10 +6,10 @@ CHROME_QA_EXT_ID=iahhmhdkmkifclacffbofcnmgkpalpoj
 CHROME_PROD_EXT_ID=bjfhmglciegochdpefhhlphglcehbmek
 
 upload_and_publish_chrome_qa_ext() {
-  # Upload and publish qa extension
-  CHROME_QA_EXT_ARCHIVE=dist/*-chrome-qa.zip
+  # Upload and publish staging extension
+  CHROME_QA_EXT_ARCHIVE=dist/*-chrome-staging.zip
   if [ ! -f $CHROME_QA_EXT_ARCHIVE ]; then
-    echo "Chrome qa extension has not been built."
+    echo "Chrome staging extension has not been built."
     exit 1
   fi
 
@@ -69,8 +69,8 @@ run_webext_sign() {
 sign_firefox_exts() {
   # Unpack the Firefox extensions ready for upload to addons.mozilla.org.
   FIREFOX_QA_EXT_ID="{b441de5f-18e6-40ad-a8c2-f1bd2d42cb01}"
-  rm -rf dist/firefox-qa
-  unzip -q dist/*-firefox-qa.xpi -d dist/firefox-qa
+  rm -rf dist/firefox-staging
+  unzip -q dist/*-firefox-staging.xpi -d dist/firefox-staging
 
   FIREFOX_PROD_EXT_ID="{32492fee-2d9f-49fe-b268-fe213f7019f0}"
   rm -rf dist/firefox-prod
@@ -78,19 +78,19 @@ sign_firefox_exts() {
 
   # Upload the Firefox extensions and wait for signing to complete.
   # This may take several minutes for each extension, so we do this for the
-  # QA and prod extensions in parallel.
-  run_webext_sign "$FIREFOX_QA_EXT_ID" dist/firefox-qa &
+  # staging and prod extensions in parallel.
+  run_webext_sign "$FIREFOX_QA_EXT_ID" dist/firefox-staging &
   qa_sign_pid=$!
 
   run_webext_sign "$FIREFOX_PROD_EXT_ID" dist/firefox-prod &
   prod_sign_pid=$!
 
-  echo "Waiting for Firefox QA signing to complete..."
+  echo "Waiting for Firefox staging signing to complete..."
   status=0
   wait $qa_sign_pid || status=$?
-  cat dist/firefox-qa/log.txt
+  cat dist/firefox-staging/log.txt
   if [[ $status -ne 0 ]]; then
-    echo "Signing Firefox QA extension failed"
+    echo "Signing Firefox staging extension failed"
     exit 1
   fi
 
@@ -106,7 +106,7 @@ sign_firefox_exts() {
   echo "Successfully signed Firefox extensions"
 }
 
-echo "Uploading and publishing Chrome (QA) extension..."
+echo "Uploading and publishing Chrome (staging) extension..."
 upload_and_publish_chrome_qa_ext
 
 echo "Uploading Chrome (prod) extension..."


### PR DESCRIPTION
Update the browser extension following the replacement of qa.hypothes.is with staging.hypothes.is.

New auth clients have been registered at https://staging.hypothes.is/admin/oauthclients.

**Testing:**

1. Remove Hypothesis QA/staging extension if already installed
2. Build local staging extension:
   ```
   make build SETTINGS_FILE=settings/chrome-staging.json
   ```
3. Load extension in Chrome and verify that you can log in and annotate

The extension now displays the letters "STG" rather than "QA" on the badge.