### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
     - name: Cache the node_modules dir
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
@@ -48,7 +48,7 @@ jobs:
         make build SETTINGS_FILE=settings/firefox-staging.json dist/ci-firefox-staging.xpi
         make build SETTINGS_FILE=settings/firefox-prod.json dist/ci-firefox-prod.xpi
     - name: Archive packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: packages
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,18 +30,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
     - name: Cache the node_modules dir
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
     - name: Install
       run: yarn install --immutable
     - name: Fetch packages
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: packages
         path: dist/

--- a/.github/workflows/update-client.yml
+++ b/.github/workflows/update-client.yml
@@ -8,9 +8,9 @@ jobs:
       ref: ${{ steps.update-client.outputs.ref }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Cache the node_modules dir
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
This should resolve warnings about use of deprecated Node 16 in workflows.

See also https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.