### PR TITLE
Load scripts as modules where possible

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,9 +36,6 @@
         "tests/karma.config.js",
 
         // Entry points which currently get loaded as non-module scripts.
-        "src/help/index.js",
-        "src/pdfjs-init.js",
-        "src/options/options.js",
         "src/unload-client.js"
       ],
       "parserOptions": {

--- a/src/help/index.html
+++ b/src/help/index.html
@@ -117,6 +117,6 @@
         </p>
       </section>
     </article>
-    <script src="./index.js"></script>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/src/help/index.js
+++ b/src/help/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Detect the current OS and show approprite help.
 chrome.runtime.getPlatformInfo(info => {
   const opts = /** @type {NodeListOf<HTMLElement>} */ (

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -20,7 +20,7 @@
         service for this data.
     </p>
 
-    <script src="options.js"></script>
+    <script type="module" src="options.js"></script>
   </main>
 </body>
 </html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Return the checkbox that toggles whether badge requests are sent.
  */

--- a/src/pdfjs-init.js
+++ b/src/pdfjs-init.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* global PDFViewerApplication */
 
 // This script is run once PDF.js has loaded and it configures the viewer

--- a/src/vendor/pdfjs/web/viewer.html
+++ b/src/vendor/pdfjs/web/viewer.html
@@ -38,7 +38,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 
   <script src="viewer.js"></script>
 
-  <script src="/pdfjs-init.js"></script></head>
+  <script type="module" src="/pdfjs-init.js"></script></head>
 
   <body tabindex="1">
     <div id="outerContainer">


### PR DESCRIPTION
Load the JS for the help, options and PDF viewer pages as modules. This makes handling of the code more consistent with the background service worker, which is written as ES modules and bundled into a script.

This PR is a small piece of cleanup prior to a future ESLint v9 upgrade.