### PR TITLE
Support OOPIF PDF viewer in Chrome

### DIFF
--- a/src/background/chrome-api.ts
+++ b/src/background/chrome-api.ts
@@ -16,8 +16,9 @@ type Callback<Result> = (r: Result) => void;
  * This is exposed for testing. Consumers should use {@link chromeAPI}.
  */
 export function getChromeAPI(chrome = globalThis.chrome) {
-  // In the test environment, the `chrome` global may not exist.
-  if (typeof chrome === 'undefined') {
+  // In the test environment, the `chrome` global may not exist or may not
+  // be the expected object.
+  if (typeof chrome === 'undefined' || !chrome.extension) {
     // The `as never` causes this branch to be ignored when TS determines the
     // return type of this function.
     return null as never;

--- a/src/background/detect-content-type.ts
+++ b/src/background/detect-content-type.ts
@@ -34,6 +34,30 @@ export function detectContentType(
     if (document_.querySelector('embed[type="application/pdf"]')) {
       return { type: 'PDF' };
     }
+
+    // Detect Chrome's PDF viewer when it is using out-of-process iframes
+    // ("OOPIF") instead of `<embed>`.
+    //
+    // In this case the DOM has a structure like:
+    //
+    // ```
+    // <body>
+    //   # closed shadow root
+    //    - <iframe type="application/pdf" ...></frame>
+    // </body>
+    // ```
+    //
+    // See https://github.com/hypothesis/support/issues/145#issuecomment-2330193036.
+    if (typeof chrome !== 'undefined') {
+      const bodyShadow = chrome.dom?.openOrClosedShadowRoot(document.body);
+      if (
+        bodyShadow &&
+        bodyShadow.querySelector('iframe[type="application/pdf"]')
+      ) {
+        return { type: 'PDF' };
+      }
+    }
+
     return null;
   }
 


### PR DESCRIPTION
Fix detection of document type in Chrome's built-in PDF viewer when the "OOPIF
for PDF Viewer" feature ("pdf-oopif") is enabled.

Fixes https://github.com/hypothesis/support/issues/145

Related upstream issue tracking launch of this Chrome change: https://issuetracker.google.com/issues/40268279

----

**Testing:**

1. In Chrome, go to chrome://flags and enable the "OOPIF PDF viewer" experiment.
2. Restart your browser
3. Build extension on main, navigate to https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf and attempt to activate the extension. It should fail to activate.
4. Check out this branch and repeat step (3). The PDF viewer should work as normal.
5. Disable the "OOPIF PDF viewer" experiment in Chrome, restart the browser and very that this branch still works with the old PDF viewer.