### PR TITLE
Simplify Chrome API wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SETTINGS_FILE := settings/chrome-dev.json
 ROLLUP := node_modules/.bin/rollup
 ESLINT := node_modules/.bin/eslint
 MUSTACHE := node_modules/.bin/mustache
-PRETTIER := node_modules/.bin/prettier
+PRETTIER := node node_modules/.bin/prettier
 
 .PHONY: default
 default: help

--- a/src/background/chrome-api.ts
+++ b/src/background/chrome-api.ts
@@ -73,7 +73,7 @@ export function getChromeAPI(chrome = globalThis.chrome) {
     },
 
     scripting: {
-      executeScript: chrome.scripting?.executeScript,
+      executeScript: chrome.scripting.executeScript,
     },
 
     storage: {

--- a/src/background/chrome-api.ts
+++ b/src/background/chrome-api.ts
@@ -8,8 +8,6 @@
  *  - Provide a seam that can be easily mocked in tests
  */
 
-type Callback<Result> = (r: Result) => void;
-
 /**
  * Wrap the browser APIs exposed via the `chrome` object to return promises.
  *
@@ -24,72 +22,23 @@ export function getChromeAPI(chrome = globalThis.chrome) {
     return null as never;
   }
 
-  /**
-   * Cache of Promise-ified APIs. This is used so that APIs which are looked up
-   * on-demand, eg. because they are optional and may not exist when `getChromeAPI`
-   * is first called, are only created once.
-   */
-  const cache = new Map<() => void, any>();
-
-  /**
-   * Convert an async callback-accepting Chrome API to a Promise-returning version.
-   *
-   * TypeScript may complain if the API has a Manifest V3-only overload that
-   * returns a Promise. Use {@link promisifyAlt} as a workaround.
-   *
-   * This wrapper can be removed once the extension becomes Manifest V3-only.
-   *
-   * @param fn - The original Chrome API that accepts a callback.
-   * @return Wrapped API that doesn't take a callback but returns a Promise instead
-   */
-  function promisify<Args extends any[], Result>(
-    fn: (...args: [...Args, Callback<Result>]) => void,
-  ): (...args: Args) => Promise<Result> {
-    const cached = cache.get(fn);
-    if (cached) {
-      return cached;
-    }
-
-    return (...args) => {
-      return new Promise((resolve, reject) => {
-        fn(...args, (result: Result) => {
-          const lastError = chrome.runtime.lastError;
-          if (lastError) {
-            reject(lastError);
-          } else {
-            resolve(result);
-          }
-        });
-      });
-    };
-  }
-
-  function promisifyAlt<Args extends any[], Result>(
-    fn: (...args: Args) => Promise<Result>,
-  ): (...args: Args) => Promise<Result> {
-    // @ts-expect-error
-    return promisify(fn);
-  }
-
   const browserAction = chrome.browserAction ?? chrome.action;
 
   return {
     browserAction: {
       onClicked: browserAction.onClicked,
-      setBadgeBackgroundColor: promisify(browserAction.setBadgeBackgroundColor),
-      setBadgeText: promisify(browserAction.setBadgeText),
-      setIcon: promisify(browserAction.setIcon),
-      setTitle: promisify(browserAction.setTitle),
+      setBadgeBackgroundColor: browserAction.setBadgeBackgroundColor,
+      setBadgeText: browserAction.setBadgeText,
+      setIcon: browserAction.setIcon,
+      setTitle: browserAction.setTitle,
     },
 
     extension: {
-      isAllowedFileSchemeAccess: promisify(
-        chrome.extension.isAllowedFileSchemeAccess,
-      ),
+      isAllowedFileSchemeAccess: chrome.extension.isAllowedFileSchemeAccess,
     },
 
     management: {
-      getSelf: promisify(chrome.management.getSelf),
+      getSelf: chrome.management.getSelf,
     },
 
     runtime: {
@@ -103,24 +52,24 @@ export function getChromeAPI(chrome = globalThis.chrome) {
 
       // Firefox (as of v92) does not support `requestUpdateCheck`.
       requestUpdateCheck: chrome.runtime.requestUpdateCheck
-        ? promisify(chrome.runtime.requestUpdateCheck)
+        ? chrome.runtime.requestUpdateCheck
         : null,
     },
 
     permissions: {
-      getAll: promisify(chrome.permissions.getAll),
-      request: promisify(chrome.permissions.request),
+      getAll: chrome.permissions.getAll,
+      request: chrome.permissions.request,
     },
 
     tabs: {
-      create: promisify(chrome.tabs.create),
-      get: promisifyAlt(chrome.tabs.get),
+      create: chrome.tabs.create,
+      get: chrome.tabs.get,
       onCreated: chrome.tabs.onCreated,
       onReplaced: chrome.tabs.onReplaced,
       onRemoved: chrome.tabs.onRemoved,
       onUpdated: chrome.tabs.onUpdated,
-      query: promisifyAlt(chrome.tabs.query),
-      update: promisify(chrome.tabs.update),
+      query: chrome.tabs.query,
+      update: chrome.tabs.update,
     },
 
     scripting: {
@@ -131,7 +80,7 @@ export function getChromeAPI(chrome = globalThis.chrome) {
       // Methods of storage areas (sync, local, managed) need to be bound.
       // Standalone functions in Chrome API namespaces do not.
       sync: {
-        get: promisify(chrome.storage.sync.get.bind(chrome.storage.sync)),
+        get: chrome.storage.sync.get.bind(chrome.storage.sync),
       },
     },
 
@@ -145,7 +94,7 @@ export function getChromeAPI(chrome = globalThis.chrome) {
 
     get webNavigation() {
       return {
-        getAllFrames: promisifyAlt(chrome.webNavigation.getAllFrames),
+        getAllFrames: chrome.webNavigation.getAllFrames,
       };
     },
   };

--- a/tests/background/chrome-api-test.js
+++ b/tests/background/chrome-api-test.js
@@ -47,6 +47,10 @@ describe('chrome-api', () => {
           update: sinon.stub(),
         },
 
+        scripting: {
+          executeScript: sinon.stub(),
+        },
+
         storage: {
           sync: {
             get: sinon.stub(),


### PR DESCRIPTION
Since the migration to Manifest V3 is now complete, all of the `chrome` APIs support returning promises, so we don't need to wrap the older callback-returning APIs to return promises. This simplifies the code and also removes the need for a TypeScript workaround when resolving the type of wrapped functions.

In the process I had to fix an error when running `make format` locally due to `node_modules/.bin/prettier` not being executable. This had been on my TODO list for a while.