### PR TITLE
Show survey to users after extension is uninstalled

### DIFF
--- a/src/background/chrome-api.ts
+++ b/src/background/chrome-api.ts
@@ -54,6 +54,8 @@ export function getChromeAPI(chrome = globalThis.chrome) {
       requestUpdateCheck: chrome.runtime.requestUpdateCheck
         ? chrome.runtime.requestUpdateCheck
         : null,
+
+      setUninstallURL: chrome.runtime.setUninstallURL,
     },
 
     permissions: {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -3,6 +3,14 @@ import { Extension } from './extension';
 import type { ExternalMessage } from './messages';
 
 /**
+ * Link to survey to show users after extension is uninstalled.
+ *
+ * See https://github.com/hypothesis/product-backlog/issues/1599.
+ */
+export const uninstallURL =
+  'https://docs.google.com/forms/d/e/1FAIpQLSd250Bi4xvxxvL-SgajHRmk8K1LMLZLGRoYkp6WSwT8PDTlLA/viewform?usp=sf_link';
+
+/**
  * Initialize the extension's Service Worker / background page.
  *
  * This is exported for use in tests.
@@ -66,6 +74,9 @@ export async function init() {
       chromeAPI.runtime.reload(),
     );
   });
+
+  // Show survey to users after they uninstall extension.
+  chromeAPI.runtime.setUninstallURL(uninstallURL);
 
   await initialized;
 }

--- a/tests/background/index-test.js
+++ b/tests/background/index-test.js
@@ -1,4 +1,4 @@
-import { init, $imports } from '../../src/background';
+import { init, uninstallURL, $imports } from '../../src/background';
 
 let extension;
 
@@ -28,6 +28,7 @@ describe('background/index', () => {
         onInstalled: eventListenerStub(),
         onMessageExternal: eventListenerStub(),
         onUpdateAvailable: eventListenerStub(),
+        setUninstallURL: sinon.stub().resolves(),
       },
       management: {
         getSelf: sinon.stub().resolves({ installType: 'normal', id: '1234' }),
@@ -71,6 +72,10 @@ describe('background/index', () => {
         installType: 'normal',
       });
     });
+  });
+
+  it('shows survey to users after extension is uninstalled', () => {
+    assert.calledWith(fakeChromeAPI.runtime.setUninstallURL, uninstallURL);
   });
 
   describe('bouncer (hyp.is) message handling', () => {


### PR DESCRIPTION
Fixes https://github.com/hypothesis/product-backlog/issues/1599

**Testing:**

1. Build and install development extension
2. Uninstall the extension
3. Chrome should open a new tab at [this URL](https://docs.google.com/forms/d/e/1FAIpQLSd250Bi4xvxxvL-SgajHRmk8K1LMLZLGRoYkp6WSwT8PDTlLA/viewform)