### PR TITLE
Fix reference to undefined `process` variable when loading extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-multi-entry": "^6.0.1",
     "@rollup/plugin-node-resolve": "^16.0.1",
+    "@rollup/plugin-replace": "^6.0.2",
     "@types/chrome": "^0.0.319",
     "@vitest/browser": "^3.1.2",
     "@vitest/coverage-istanbul": "^3.1.2",

--- a/rollup-tests.config.js
+++ b/rollup-tests.config.js
@@ -4,6 +4,7 @@ import { babel } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import multi from '@rollup/plugin-multi-entry';
+import replace from '@rollup/plugin-replace';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 export default {
@@ -49,6 +50,10 @@ export default {
           },
         ],
       ],
+    }),
+    replace({
+      preventAssignment: true,
+      EXTENSION_TESTS: 'true',
     }),
     nodeResolve({ extensions: ['.js', '.ts'] }),
     commonjs(),

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -81,8 +81,11 @@ export async function init() {
   await initialized;
 }
 
+// Set by Rollup in tests
+declare const EXTENSION_TESTS: undefined | string;
+
 // Vitest sets NODE_ENV to test
-const inTests = process.env.NODE_ENV === 'test';
+const inTests = typeof EXTENSION_TESTS !== 'undefined';
 if (!inTests) {
   init();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1881,6 +1881,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-replace@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "@rollup/plugin-replace@npm:6.0.2"
+  dependencies:
+    "@rollup/pluginutils": ^5.0.1
+    magic-string: ^0.30.3
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: ef1af8d8cfca3ecf95c85bbcccf6fea3619343f6fc7c48b23ece6485a21622b74ab093a971ffc177af04468aef45c278d3b8a82f7a426d2c25da1061923cf943
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-virtual@npm:^3.0.0":
   version: 3.0.1
   resolution: "@rollup/plugin-virtual@npm:3.0.1"
@@ -6174,6 +6189,7 @@ __metadata:
     "@rollup/plugin-json": ^6.1.0
     "@rollup/plugin-multi-entry": ^6.0.1
     "@rollup/plugin-node-resolve": ^16.0.1
+    "@rollup/plugin-replace": ^6.0.2
     "@types/chrome": ^0.0.319
     "@vitest/browser": ^3.1.2
     "@vitest/coverage-istanbul": ^3.1.2


### PR DESCRIPTION
The `process` variable does not exist at all when the background script is loaded in Chrome normally. Resolve this in a similar way to the @hypothesis/lms repo [^1] by defining a variable using @rollup/plugin-replace instead.

Using `process.env.NODE_ENV` works in some of our other projects because they use @rollup/plugin-replace to replace it at build time. This is non-obvious from looking at the code however, so I think we should probably use a more-obvious custom variable.

[^1]: https://github.com/hypothesis/lms/blob/bc01ef9b7015b4c460250bf65b311b014e17368f/rollup-tests.config.js#L44