### PR TITLE
Disable automatic upload of extension after commits to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,6 @@ on:
         required: false
         type: string
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   continuous-integration:

--- a/.github/workflows/update-client.yml
+++ b/.github/workflows/update-client.yml
@@ -23,16 +23,3 @@ jobs:
         git config --global user.email "hypothesis@users.noreply.github.com"
         tools/update-client
         echo "ref=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-  # Release a new version of the extension with the updated client.
-  #
-  # Pushes to the main branch normally trigger this workflow automatically,
-  # but the push by the update-client job doesn't due to GitHub Actions restrictions.
-  # See https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow.
-  release:
-    needs: update-client
-    uses: ./.github/workflows/release.yml
-    name: Release extension
-    secrets: inherit
-    with:
-      ref: ${{ needs.update-client.outputs.ref }}


### PR DESCRIPTION
Remove the workflow steps that automatically automatically build and upload the QA and production extensions after commits to main. The release fails if there is a draft extension in the pending review state when an extension is uploaded. This has been happening frequently in recent weeks due to reviews in the Chrome Web Store having become much slower, for both the QA and production extension. Previously reviews would often happen in 30 minutes or so, but now sometimes take several days. Hence automated releases frequently failed.

Instead switch to a process where extension releases are triggered manually:

 1. Go to the Chrome Web Store and verify that the QA and production extensions are both released and not in a pending-review state. If either is in a pending review state, either wait for the review to be completed or cancel the review.

 2. Go to https://github.com/hypothesis/browser-extension/actions/workflows/release.yml and run the Release workflow manually.

 3. Wait for the QA extension to be reviewed in the Chrome Web Store and verify the extension works as expected.

 4. Publish the production extension in the Chrome Web Store

There is documentation in https://github.com/hypothesis/playbook/blob/main/docs/chrome-extension.md that will need to be updated after this lands.