### PR TITLE
Add vitest Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
     typescript-types:
       patterns:
         - '@types/*'
+    vitest:
+      patterns:
+        - 'vitest'
+        - '@vitest/*'


### PR DESCRIPTION
Add the same "vitest" group that exists in the hypothesis/client repo. This ensures that the vitest sub-packages are updated together. Mixing different versions of `@vitest/browser` and `vitest` for example caused a failure in https://github.com/hypothesis/browser-extension/actions/runs/14974780002/job/42064210348?pr=1738.