### PR TITLE
Remove references to cdn.hypothes.is from boot script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ build/manifest.json: src/manifest.json.mustache build/settings.json
 build/client/build: node_modules/hypothesis/build/manifest.json
 	@mkdir -p $@
 	cp -R node_modules/hypothesis/build/* $@
+	@# Replace boot template with extension-specific URLs.
+	node tools/render-boot-template.js $@/boot-template.js $@/boot.js
+	rm $@/boot-template.js
 	@# We can't leave the client manifest in the build or the Chrome Web Store
 	@# will complain.
 	rm $@/manifest.json

--- a/tools/render-boot-template.js
+++ b/tools/render-boot-template.js
@@ -1,0 +1,39 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+/**
+ * Replace placeholders in the client's boot script with real URLs.
+ *
+ * Placeholders are single or double-quoted string literals of the form
+ * `"__VARIABLE_NAME__"`.
+ */
+export function renderBootTemplate(src, dest) {
+  const getURLCode = path => `chrome.runtime.getURL("${path}")`;
+
+  const assetRoot = getURLCode('/client/');
+  const notebookAppUrl = getURLCode('/client/notebook.html');
+  const profileAppUrl = getURLCode('/client/profile.html');
+  const sidebarAppUrl = getURLCode('/client/app.html');
+
+  const replacements = {
+    __ASSET_ROOT__: assetRoot,
+    __NOTEBOOK_APP_URL__: notebookAppUrl,
+    __PROFILE_APP_URL__: profileAppUrl,
+    __SIDEBAR_APP_URL__: sidebarAppUrl,
+  };
+  const template = readFileSync(src, { encoding: 'utf8' });
+  const bootScript = template.replaceAll(
+    /"(__[A-Z_0-9]+__)"|'(__[A-Z_0-9]+__)'/g,
+    (match, doubleQuoted, singleQuoted) => {
+      const name = doubleQuoted || singleQuoted;
+      if (!Object.hasOwn(replacements, name)) {
+        throw new Error(`Unknown placeholder "${name}" in boot template`);
+      }
+      return replacements[name];
+    },
+  );
+  writeFileSync(dest, bootScript);
+}
+
+const src = process.argv[2];
+const dest = process.argv[3];
+renderBootTemplate(src, dest);


### PR DESCRIPTION
When packaging the Hypothesis client for inclusion in the extension, replace the boot script containing cdn.hypothes.is URLs with one that references client-bundled URLs via `chrome.runtime.getURL`. We still set `assetRoot` and related URLs in order to support annotation-enabled same-origin iframes, so the new URLs are not actually used. Importantly however, the remote CDN URLs no longer appear in the bundle. This avoids giving the mistaken impression that we were loading remote code.

See https://github.com/hypothesis/client/pull/7099.

CI will fail until the client is updated to include https://github.com/hypothesis/client/pull/7099.