### PR TITLE
Security: Potential prototype pollution in settings merge

### DIFF
--- a/src/background/settings.ts
+++ b/src/background/settings.ts
@@ -16,11 +16,24 @@ import rawSettings from '../../build/settings.json';
 /**
  * Configuration data for the extension.
  */
-const settings: Settings = {
-  ...rawSettings,
+const raw = rawSettings as Record<string, unknown>;
 
-  // Ensure API url does not end with '/'
-  apiUrl: rawSettings.apiUrl.replace(/\/$/, ''),
+function isValidSettings(obj: Record<string, unknown>): obj is Record<keyof Settings, unknown> {
+  return (
+    typeof obj.apiUrl === 'string' &&
+    typeof obj.buildType === 'string' &&
+    typeof obj.serviceUrl === 'string'
+  );
+}
+
+if (!isValidSettings(raw)) {
+  throw new Error('Invalid settings.json structure');
+}
+
+const settings: Settings = {
+  apiUrl: raw.apiUrl.replace(/\/$/, ''),
+  buildType: raw.buildType,
+  serviceUrl: raw.serviceUrl,
 };
 
 export default settings;


### PR DESCRIPTION
## Summary

Security: Potential prototype pollution in settings merge

## Problem

**Severity**: `Low` | **File**: `src/background/settings.ts:L16`

In `src/background/settings.ts`, the settings object is created using spread syntax with `...rawSettings`. While this is generally safe, if `rawSettings` were ever to contain `__proto__`, `constructor`, or `prototype` keys (which could happen if the JSON file were tampered with), it could lead to prototype pollution. Additionally, the code imports raw JSON and spreads it directly. The `replace` operation on `apiUrl` also doesn't validate that `apiUrl` is actually a string before calling `.replace()`.

## Solution

Validate the structure and types of `rawSettings` before spreading. Use `Object.create(null)` for the base object or validate that no dangerous keys exist. Ensure `apiUrl` is a string before calling string methods on it.

## Changes

- `src/background/settings.ts` (modified)